### PR TITLE
Added a dedicated mapped array overload for all functions that accept…

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Functions that accept collections
 [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), etc.)
 should accept any
 [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol)
-rather than a specific collection type. This _generally_ more flexibility and improved performance.
+rather than a specific collection type. This is _generally_ more flexible and improves performance.
 
 ```ts
 // ✓ Good: Accepts any iterable

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ const Example: ExampleConstructor = class {
 `${new Example()}`; // "[object Example]"
 ```
 
-### Prefer Iterables Over Arrays
+### Prefer [Iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) Over [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)s
 
 Functions that accept collections
 ([`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array),

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Functions that accept collections
 [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), etc.)
 should accept any
 [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol)
-rather than a specific collection type. This is _generally_ more flexible and improves performance.
+rather than a specific collection type. This is _generally_ more flexible and performant.
 
 ```ts
 // ✓ Good: Accepts any iterable

--- a/README.md
+++ b/README.md
@@ -165,6 +165,27 @@ const Example: ExampleConstructor = class {
 `${new Example()}`; // "[object Example]"
 ```
 
+### Prefer Iterables Over Arrays
+
+Functions that accept collections
+([`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array),
+[`Set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set),
+[`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), etc.)
+should accept any
+[iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol)
+rather than a specific collection type. This _generally_ more flexibility and improved performance.
+
+```ts
+// ✓ Good: Accepts any iterable
+function sum(values: Iterable<number>): number;
+
+// ✗ Bad: Restricts to arrays unnecessarily
+function sum(values: Array<number>): number;
+```
+
+**Exception:** Use specific collection types when there's a concrete performance or correctness
+requirement.
+
 ### Pure Functions
 
 Functions should be pure wherever possible:

--- a/flat/deno.json
+++ b/flat/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/flat",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/flat/mod.ts
+++ b/flat/mod.ts
@@ -47,7 +47,7 @@ export function flat<Value>(
   sources: Iterable<Observable<Value>>,
 ): Observable<Value>;
 export function flat<Value>(
-  // Accepting any iterable is a design choice for performance (iterables are 
+  // Accepting any iterable is a design choice for performance (iterables are
   // lazily evaluated) and flexibility.
   sources: Iterable<Observable<Value>>,
 ): Observable<Value> {

--- a/flat/mod.ts
+++ b/flat/mod.ts
@@ -47,8 +47,8 @@ export function flat<Value>(
   sources: Iterable<Observable<Value>>,
 ): Observable<Value>;
 export function flat<Value>(
-  // Accepting any iterable is a design choice for performance (iterables are lazily evaluated) and
-  // flexibility (can accept any iterable, not just arrays).
+  // Accepting any iterable is a design choice for performance (iterables are 
+  // lazily evaluated) and flexibility.
   sources: Iterable<Observable<Value>>,
 ): Observable<Value> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();

--- a/flat/mod.ts
+++ b/flat/mod.ts
@@ -40,8 +40,14 @@ import { flatMap } from "@observable/flat-map";
  * // "return"
  * ```
  */
+export function flat<const Values extends ReadonlyArray<unknown>>(
+  sources: Readonly<{ [Key in keyof Values]: Observable<Values[Key]> }>,
+): Observable<Values[number]>;
 export function flat<Value>(
-  // Accepting an Iterable is a design choice for performance (iterables are lazily evaluated) and
+  sources: Iterable<Observable<Value>>,
+): Observable<Value>;
+export function flat<Value>(
+  // Accepting any iterable is a design choice for performance (iterables are lazily evaluated) and
   // flexibility (can accept any iterable, not just arrays).
   sources: Iterable<Observable<Value>>,
 ): Observable<Value> {

--- a/merge/deno.json
+++ b/merge/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/merge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/merge/mod.ts
+++ b/merge/mod.ts
@@ -42,8 +42,14 @@ import { mergeMap } from "@observable/merge-map";
  * source3.return(); // "return"
  * ```
  */
+export function merge<const Values extends ReadonlyArray<unknown>>(
+  sources: Readonly<{ [Key in keyof Values]: Observable<Values[Key]> }>,
+): Observable<Values[number]>;
 export function merge<Value>(
-  // Accepting an Iterable is a design choice for performance (iterables are lazily evaluated) and
+  sources: Iterable<Observable<Value>>,
+): Observable<Value>;
+export function merge<Value>(
+  // Accepting any iterable is a design choice for performance (iterables are lazily evaluated) and
   // flexibility (can accept any iterable, not just arrays).
   sources: Iterable<Observable<Value>>,
 ): Observable<Value> {

--- a/merge/mod.ts
+++ b/merge/mod.ts
@@ -49,8 +49,8 @@ export function merge<Value>(
   sources: Iterable<Observable<Value>>,
 ): Observable<Value>;
 export function merge<Value>(
-  // Accepting any iterable is a design choice for performance (iterables are lazily evaluated) and
-  // flexibility (can accept any iterable, not just arrays).
+  // Accepting any iterable is a design choice for performance (iterables are 
+  // lazily evaluated) and flexibility.
   sources: Iterable<Observable<Value>>,
 ): Observable<Value> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();

--- a/merge/mod.ts
+++ b/merge/mod.ts
@@ -49,7 +49,7 @@ export function merge<Value>(
   sources: Iterable<Observable<Value>>,
 ): Observable<Value>;
 export function merge<Value>(
-  // Accepting any iterable is a design choice for performance (iterables are 
+  // Accepting any iterable is a design choice for performance (iterables are
   // lazily evaluated) and flexibility.
   sources: Iterable<Observable<Value>>,
 ): Observable<Value> {

--- a/of/deno.json
+++ b/of/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/of",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/of/mod.ts
+++ b/of/mod.ts
@@ -56,8 +56,8 @@ export function of<Value>(
   values: Iterable<Value>,
 ): Observable<Value>;
 export function of<Value>(
-  // Accepting any iterable is a design choice for performance (iterables are lazily evaluated) and
-  // flexibility (can accept any iterable, not just arrays).
+  // Accepting any iterable is a design choice for performance (iterables are 
+  // lazily evaluated) and flexibility.
   values: Iterable<Value>,
 ): Observable<Value> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();

--- a/of/mod.ts
+++ b/of/mod.ts
@@ -56,7 +56,7 @@ export function of<Value>(
   values: Iterable<Value>,
 ): Observable<Value>;
 export function of<Value>(
-  // Accepting any iterable is a design choice for performance (iterables are 
+  // Accepting any iterable is a design choice for performance (iterables are
   // lazily evaluated) and flexibility.
   values: Iterable<Value>,
 ): Observable<Value> {

--- a/of/mod.ts
+++ b/of/mod.ts
@@ -49,8 +49,14 @@ import {
  * // "next" 2
  * ```
  */
+export function of<const Values extends ReadonlyArray<unknown>>(
+  values: Values,
+): Observable<Values[number]>;
 export function of<Value>(
-  // Accepting an Iterable is a design choice for performance (iterables are lazily evaluated) and
+  values: Iterable<Value>,
+): Observable<Value>;
+export function of<Value>(
+  // Accepting any iterable is a design choice for performance (iterables are lazily evaluated) and
   // flexibility (can accept any iterable, not just arrays).
   values: Iterable<Value>,
 ): Observable<Value> {

--- a/race/deno.json
+++ b/race/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/race",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/race/mod.ts
+++ b/race/mod.ts
@@ -45,8 +45,14 @@ import { AsyncSubject } from "@observable/async-subject";
  * source2.return(); // "return"
  * ```
  */
+export function race<const Values extends ReadonlyArray<unknown>>(
+  sources: Readonly<{ [Key in keyof Values]: Observable<Values[Key]> }>,
+): Observable<Values[number]>;
 export function race<Value>(
-  // Accepting an Iterable is a design choice for performance (iterables are lazily evaluated) and
+  sources: Iterable<Observable<Value>>,
+): Observable<Value>;
+export function race<Value>(
+  // Accepting any iterable is a design choice for performance (iterables are lazily evaluated) and
   // flexibility (can accept any iterable, not just arrays).
   sources: Iterable<Observable<Value>>,
 ): Observable<Value> {

--- a/race/mod.ts
+++ b/race/mod.ts
@@ -52,8 +52,8 @@ export function race<Value>(
   sources: Iterable<Observable<Value>>,
 ): Observable<Value>;
 export function race<Value>(
-  // Accepting any iterable is a design choice for performance (iterables are lazily evaluated) and
-  // flexibility (can accept any iterable, not just arrays).
+  // Accepting any iterable is a design choice for performance (iterables are 
+  // lazily evaluated) and flexibility.
   sources: Iterable<Observable<Value>>,
 ): Observable<Value> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();

--- a/race/mod.ts
+++ b/race/mod.ts
@@ -52,7 +52,7 @@ export function race<Value>(
   sources: Iterable<Observable<Value>>,
 ): Observable<Value>;
 export function race<Value>(
-  // Accepting any iterable is a design choice for performance (iterables are 
+  // Accepting any iterable is a design choice for performance (iterables are
   // lazily evaluated) and flexibility.
   sources: Iterable<Observable<Value>>,
 ): Observable<Value> {


### PR DESCRIPTION
… an iterable. This allows a union value to be generated when the provided argument is a tuple.