### PR TITLE
Update version numbers and enhance documentation across multiple modu…

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -354,3 +354,30 @@ Deno.test("should describe expected behavior", () => {
 9. ❌ Forgetting to check `observer.signal.aborted` before operations
 10. ❌ Missing argument validation in public functions
 11. ❌ Assuming RxJS teardown ordering (this library aborts BEFORE terminal notification handlers run)
+
+---
+
+## Documentation Style Guidelines
+
+### Terminology
+- ✅ Say Observables "return" — NOT "complete"
+- ✅ Say Observables "throw" — NOT "error"
+- ✅ "The source returns" — NOT "The source completes"
+- ✅ "After the Observable returns" — NOT "After the Observable completes"
+
+### Variable Naming
+- ❌ Do NOT use Finnish notation (the `$` suffix for Observables)
+- ✅ Use descriptive names: `source`, `notifier`, `input`, `result`
+- ❌ Avoid: `source$`, `input$`, `click$`, `destroy$`
+
+### Examples
+```ts
+// ✓ CORRECT variable naming
+const source = new Subject<number>();
+const notifier = new Subject<void>();
+const controller = new AbortController();
+
+// ✗ WRONG - Finnish notation
+const source$ = new Subject<number>();
+const click$ = fromEvent(button, "click");
+```

--- a/all/README.md
+++ b/all/README.md
@@ -60,6 +60,63 @@ all([of([1, 2, 3]), empty, of([7, 8, 9])]).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/all from the @observable library ecosystem.
+
+WHAT IT DOES:
+`all(sources)` creates an Observable that emits arrays containing the latest value from each source. Only starts emitting once ALL sources have emitted at least once. If any source is empty, the result is empty.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- Similar to RxJS `combineLatest`
+
+USAGE PATTERN:
+```ts
+import { all } from "@observable/all";
+import { of } from "@observable/of";
+
+const controller = new AbortController();
+
+all([
+  of([1, 2, 3]),
+  of([4, 5, 6]),
+  of([7, 8, 9])
+]).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+
+// Output:
+// [3, 6, 7]  — all sources have emitted, combining latest
+// [3, 6, 8]
+// [3, 6, 9]
+// "done"
+```
+
+EMPTY SOURCE BEHAVIOR:
+```ts
+import { empty } from "@observable/empty";
+
+all([of([1, 2, 3]), empty, of([7, 8, 9])]).subscribe({
+  next: (value) => console.log(value),  // Never called!
+  return: () => console.log("done"),    // Called immediately
+  ...
+});
+// Output: "done" (because one source is empty)
+```
+
+SEE ALSO:
+- `merge` — emits individual values from all sources
+- `race` — mirrors only the first source to emit
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/all/deno.json
+++ b/all/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/all",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/as-async-iterable/README.md
+++ b/as-async-iterable/README.md
@@ -32,6 +32,57 @@ for await (const value of pipe(of([1, 2, 3]), asAsyncIterable())) {
 // 3
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/as-async-iterable from the @observable library ecosystem.
+
+WHAT IT DOES:
+`asAsyncIterable()` converts an Observable to an AsyncIterable, allowing you to use `for await...of` loops.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `asAsyncIterable` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { asAsyncIterable } from "@observable/as-async-iterable";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+for await (const value of pipe(of([1, 2, 3]), asAsyncIterable())) {
+  console.log(value);
+}
+// Output:
+// 1
+// 2
+// 3
+```
+
+ERROR HANDLING:
+```ts
+try {
+  for await (const value of pipe(someObservable, asAsyncIterable())) {
+    console.log(value);
+  }
+} catch (error) {
+  console.error("Observable threw:", error);
+}
+```
+
+BREAKING OUT OF LOOP:
+Breaking out of the loop will unsubscribe from the Observable:
+```ts
+for await (const value of pipe(interval(100), asAsyncIterable())) {
+  console.log(value);
+  if (value === 5) break;  // Unsubscribes from interval
+}
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/as-async-iterable/deno.json
+++ b/as-async-iterable/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/as-async-iterable",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/as-promise/README.md
+++ b/as-promise/README.md
@@ -80,6 +80,59 @@ try {
 }
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/as-promise from the @observable library ecosystem.
+
+WHAT IT DOES:
+`asPromise()` converts an Observable to a Promise that resolves with the LAST emitted value. Rejects if the source throws, or if the source returns without emitting any value.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `asPromise` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { asPromise } from "@observable/as-promise";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const result = await pipe(of([1, 2, 3]), asPromise());
+console.log(result);  // 3 (last value)
+```
+
+ERROR HANDLING:
+```ts
+import { throwError } from "@observable/throw-error";
+
+try {
+  await pipe(throwError(new Error("test")), asPromise());
+} catch (error) {
+  console.error(error);  // Error: test
+}
+```
+
+EMPTY OBSERVABLE REJECTION:
+```ts
+import { empty } from "@observable/empty";
+
+try {
+  await pipe(empty, asPromise());
+} catch (error) {
+  console.error(error);  // TypeError: Cannot convert empty Observable to Promise
+}
+```
+
+IMPORTANT:
+- Resolves with the LAST value, not the first
+- Rejects with TypeError if Observable returns without emitting
+- Rejects with the thrown value if Observable throws
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/as-promise/deno.json
+++ b/as-promise/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/as-promise",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/async-subject/deno.json
+++ b/async-subject/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/async-subject",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/behavior-subject/README.md
+++ b/behavior-subject/README.md
@@ -56,6 +56,65 @@ subject.subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/behavior-subject from the @observable library ecosystem.
+
+WHAT IT DOES:
+`BehaviorSubject` is a Subject that requires an initial value and replays the current (most recent) value to new subscribers immediately upon subscription.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- Subject uses `next()`, `return()`, `throw()` — NOT `next()`, `complete()`, `error()`
+
+USAGE PATTERN:
+```ts
+import { BehaviorSubject } from "@observable/behavior-subject";
+
+const subject = new BehaviorSubject(0);  // Initial value required
+const controller = new AbortController();
+
+subject.subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // Immediately: 0
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+
+subject.next(1);  // logs: 1
+subject.next(2);  // logs: 2
+
+// New subscriber gets current value immediately
+subject.subscribe({
+  signal: controller.signal,
+  next: (value) => console.log("New:", value),  // Immediately: "New:" 2
+  ...
+});
+
+subject.return();  // Both subscribers: "done"
+```
+
+AFTER RETURN:
+New subscribers to a BehaviorSubject that has already returned receive only `return()`:
+```ts
+subject.return();
+subject.subscribe({
+  next: (value) => console.log(value),  // Never called
+  return: () => console.log("done"),     // Called immediately
+  ...
+});
+```
+
+SEE ALSO:
+- `Subject` — no replay, only future values
+- `ReplaySubject` — replays N most recent values
+- `AsyncSubject` — emits last value only on return
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/behavior-subject/deno.json
+++ b/behavior-subject/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/behavior-subject",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/broadcast-subject/README.md
+++ b/broadcast-subject/README.md
@@ -54,6 +54,63 @@ subject2.return(); // subject2 returned
 subject1.next(3); // No console output since subject2 is already returned
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/broadcast-subject from the @observable library ecosystem.
+
+WHAT IT DOES:
+`BroadcastSubject` is a Subject that broadcasts values ONLY to OTHER BroadcastSubject instances with the same name, across different browsing contexts (e.g., browser tabs). It does NOT receive its own emissions.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- Subject uses `next()`, `return()`, `throw()` — NOT `next()`, `complete()`, `error()`
+- Uses browser's BroadcastChannel API under the hood
+
+USAGE PATTERN:
+```ts
+import { BroadcastSubject } from "@observable/broadcast-subject";
+
+// In Tab 1:
+const subject1 = new BroadcastSubject<number>("myChannel");
+const controller1 = new AbortController();
+
+subject1.subscribe({
+  signal: controller1.signal,
+  next: (value) => console.log("Tab1 received:", value),
+  return: () => console.log("Tab1 done"),
+  throw: (error) => console.error(error),
+});
+
+// In Tab 2:
+const subject2 = new BroadcastSubject<number>("myChannel");
+const controller2 = new AbortController();
+
+subject2.subscribe({
+  signal: controller2.signal,
+  next: (value) => console.log("Tab2 received:", value),
+  return: () => console.log("Tab2 done"),
+  throw: (error) => console.error(error),
+});
+
+subject1.next(1);  // Tab2 receives 1 (Tab1 does NOT)
+subject2.next(2);  // Tab1 receives 2 (Tab2 does NOT)
+```
+
+KEY BEHAVIOR:
+- Values are structured cloned across contexts
+- Subject does NOT receive its own emissions
+- Same name = same channel
+
+USE CASES:
+- Sync state across browser tabs
+- Cross-tab communication
+- Logout from all tabs
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/broadcast-subject/deno.json
+++ b/broadcast-subject/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/broadcast-subject",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/catch-error/README.md
+++ b/catch-error/README.md
@@ -41,6 +41,70 @@ pipe(
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/catch-error from the @observable library ecosystem.
+
+WHAT IT DOES:
+`catchError(handler)` catches errors (thrown values) from the source Observable and returns a new Observable to continue the stream. Similar to try/catch for Observables.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `catchError` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { catchError } from "@observable/catch-error";
+import { throwError } from "@observable/throw-error";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  throwError(new Error("something went wrong")),
+  catchError((error) => of(["fallback value"]))
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // "fallback value"
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+HANDLER RECEIVES THE ERROR:
+```ts
+pipe(
+  someObservable,
+  catchError((error) => {
+    console.error("Caught:", error);
+    // Return a fallback Observable
+    return of(["default"]);
+  })
+).subscribe({ ... });
+```
+
+RE-THROWING ERRORS:
+```ts
+import { throwError } from "@observable/throw-error";
+
+pipe(
+  someObservable,
+  catchError((error) => {
+    if (error instanceof RecoverableError) {
+      return of(["recovered"]);
+    }
+    // Re-throw unrecoverable errors
+    return throwError(error);
+  })
+).subscribe({ ... });
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/catch-error/deno.json
+++ b/catch-error/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/catch-error",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/core/README.md
+++ b/core/README.md
@@ -306,3 +306,67 @@ there's no longer the need for a custom `Subscription` implementation. This make
 integrate with other APIs that support abort signals (like
 [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch)) while also solving the
 ["synchronous firehose" problem](https://github.com/ReactiveX/rxjs/discussions/6345).
+
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/core, a lightweight RxJS-inspired Observable library that is FUNDAMENTALLY DIFFERENT from RxJS.
+
+CRITICAL DIFFERENCES FROM RxJS:
+1. Observer methods: `next`, `return`, `throw` — NOT `next`, `complete`, `error`
+2. Unsubscription: Use `AbortController`/`AbortSignal` — NOT `Subscription.unsubscribe()`
+3. `subscribe()` returns `void` — NOT a Subscription object
+4. Teardown: Use `observer.signal.addEventListener("abort", cleanup)` — NOT return a teardown function
+5. Operators: Standalone curried functions with `pipe()` — NOT methods on Observable
+6. Teardown ordering: Abort happens BEFORE terminal notification handlers run (fixes RxJS bug)
+
+OBSERVER INTERFACE:
+```ts
+interface Observer<Value> {
+  readonly signal: AbortSignal;
+  next(value: Value): void;
+  return(): void;      // Called when producer finishes successfully
+  throw(value: unknown): void;  // Called when producer errors
+}
+```
+
+SUBSCRIPTION PATTERN:
+```ts
+const controller = new AbortController();
+observable.subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+// To unsubscribe:
+controller.abort();
+```
+
+CREATING OBSERVABLES:
+```ts
+new Observable<T>((observer) => {
+  // Setup producer
+  const cleanup = () => { /* cleanup logic */ };
+  
+  observer.signal.addEventListener("abort", cleanup, { once: true });
+  
+  // Emit values
+  observer.next(value);
+  
+  // Finish successfully
+  observer.return();
+  // OR throw error
+  observer.throw(error);
+});
+```
+
+COMMON MISTAKES TO AVOID:
+- Using `complete()` instead of `return()`
+- Using `error()` instead of `throw()`
+- Returning a teardown function from Observable constructor
+- Expecting `subscribe()` to return a Subscription
+- Using `subscription.unsubscribe()` instead of `controller.abort()`
+````

--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/debounce/README.md
+++ b/debounce/README.md
@@ -42,6 +42,53 @@ source.next(3); // Only this value will be emitted after 100ms
 // "next" 3
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/debounce from the @observable library ecosystem.
+
+WHAT IT DOES:
+`debounce(ms)` delays emissions from the source, only emitting a value after `ms` milliseconds have passed without another value being emitted. Useful for search inputs, resize events, etc.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `debounce` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { debounce } from "@observable/debounce";
+import { Subject } from "@observable/core";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+const input = new Subject<string>();
+
+pipe(
+  input,
+  debounce(300)  // Wait 300ms of silence before emitting
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log("search:", value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+
+// Rapid typing:
+input.next("h");    // (ignored)
+input.next("he");   // (ignored)
+input.next("hel");  // (ignored)
+input.next("hell"); // (ignored)
+input.next("hello"); 
+// After 300ms of no input: logs "search: hello"
+```
+
+SEE ALSO:
+- `throttle(ms)` — emits first value, then ignores for duration
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/debounce/deno.json
+++ b/debounce/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/debounce",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/defer/README.md
+++ b/defer/README.md
@@ -57,6 +57,65 @@ observable.subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/defer from the @observable library ecosystem.
+
+WHAT IT DOES:
+`defer(factory)` creates an Observable that calls a factory function on each subscription to create a new Observable. Useful for lazy evaluation and per-subscription state.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+
+USAGE PATTERN:
+```ts
+import { defer } from "@observable/defer";
+import { of } from "@observable/of";
+
+const controller = new AbortController();
+let values = [1, 2, 3];
+
+const deferred = defer(() => of(values));
+
+deferred.subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1, 2, 3
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+
+values = [4, 5, 6];
+
+deferred.subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 4, 5, 6
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+LAZY EVALUATION:
+The factory is called at subscription time, not creation time:
+```ts
+const deferred = defer(() => {
+  console.log("Factory called!");  // Only when subscribed
+  return of([Date.now()]);
+});
+// Factory not called yet...
+deferred.subscribe({ ... });  // "Factory called!"
+```
+
+USE CASES:
+- Fresh timestamp/random values per subscription
+- Per-subscription state initialization
+- Lazy resource allocation
+- Conditional Observable creation
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/defer/deno.json
+++ b/defer/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/defer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/distinct-until-changed/README.md
+++ b/distinct-until-changed/README.md
@@ -39,6 +39,56 @@ pipe(of([1, 1, 1, 2, 2, 3]), distinctUntilChanged()).subscribe({
 // return
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/distinct-until-changed from the @observable library ecosystem.
+
+WHAT IT DOES:
+`distinctUntilChanged(comparator?)` only emits when the current value is different from the previous value. Uses `Object.is` by default, or a custom comparator if provided.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `distinctUntilChanged` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { distinctUntilChanged } from "@observable/distinct-until-changed";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 1, 1, 2, 2, 3, 1]),  // Note: 1 repeats at end
+  distinctUntilChanged()
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1, 2, 3, 1
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+WITH CUSTOM COMPARATOR:
+```ts
+pipe(
+  of([{ id: 1 }, { id: 1 }, { id: 2 }]),
+  distinctUntilChanged((a, b) => a.id === b.id)
+).subscribe({ ... });  // { id: 1 }, { id: 2 }
+```
+
+DIFFERENCE FROM `distinct()`:
+- `distinct()` — filters ALL duplicates ever seen
+- `distinctUntilChanged()` — only filters CONSECUTIVE duplicates
+
+SEE ALSO:
+- `distinct()` — filters all duplicates across the stream
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/distinct-until-changed/deno.json
+++ b/distinct-until-changed/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/distinct-until-changed",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/distinct/README.md
+++ b/distinct/README.md
@@ -40,6 +40,49 @@ pipe(of([1, 2, 2, 3, 1, 3]), distinct()).subscribe({
 // return
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/distinct from the @observable library ecosystem.
+
+WHAT IT DOES:
+`distinct()` only emits values that have never been emitted before (across the entire stream). Uses a Set internally to track seen values.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `distinct` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { distinct } from "@observable/distinct";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 2, 3, 1, 3, 4]),
+  distinct()
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1, 2, 3, 4
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+BEHAVIOR:
+- First occurrence of each value is emitted
+- Subsequent duplicates are filtered out
+- Comparison is based on value identity (like Set behavior)
+
+SEE ALSO:
+- `distinctUntilChanged()` — only filters consecutive duplicates
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/distinct/deno.json
+++ b/distinct/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/distinct",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/drop/README.md
+++ b/drop/README.md
@@ -38,6 +38,56 @@ pipe(of([1, 2, 3, 4, 5]), drop(2)).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/drop from the @observable library ecosystem.
+
+WHAT IT DOES:
+`drop(count)` skips the first `count` values from the source Observable, then emits the rest.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `drop` is a standalone function used with `pipe()` — NOT a method on Observable
+- Called `drop` here, similar to RxJS's `skip`
+
+USAGE PATTERN:
+```ts
+import { drop } from "@observable/drop";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3, 4, 5]),
+  drop(2)
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 3, 4, 5
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+COMBINING WITH TAKE:
+```ts
+// Get items 3-5 from a sequence
+pipe(
+  of([1, 2, 3, 4, 5, 6, 7]),
+  drop(2),   // Skip first 2
+  take(3),   // Take next 3
+).subscribe({ ... });  // 3, 4, 5
+```
+
+SEE ALSO:
+- `take(count)` — takes only first N values
+- `filter(predicate)` — filters by condition
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/drop/deno.json
+++ b/drop/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/drop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/empty/README.md
+++ b/empty/README.md
@@ -35,6 +35,61 @@ empty.subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/empty from the @observable library ecosystem.
+
+WHAT IT DOES:
+`empty` is an Observable constant that immediately calls `return()` on subscribe without emitting any values. Useful as a no-op or to signal early return.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `empty` is a constant, not a function — use as `empty` not `empty()`
+
+USAGE PATTERN:
+```ts
+import { empty } from "@observable/empty";
+
+const controller = new AbortController();
+
+empty.subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // Never called
+  return: () => console.log("done"),    // Called immediately
+  throw: (error) => console.error(error),
+});
+// Output: "done"
+```
+
+COMMON USE — Swallow errors:
+```ts
+import { catchError } from "@observable/catch-error";
+import { pipe } from "@observable/pipe";
+
+pipe(
+  someObservable,
+  catchError((error) => {
+    console.log("Swallowing error:", error);
+    return empty;  // Return without emitting
+  })
+).subscribe({ ... });
+```
+
+COMMON USE — Default case:
+```ts
+const getObservable = (condition: boolean) =>
+  condition ? of([1, 2, 3]) : empty;
+```
+
+SEE ALSO:
+- `never` — never emits and never returns
+- `throwError(value)` — immediately throws an error
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/empty/deno.json
+++ b/empty/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/empty",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/exhaust-map/README.md
+++ b/exhaust-map/README.md
@@ -46,6 +46,67 @@ pipe(
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/exhaust-map from the @observable library ecosystem.
+
+WHAT IT DOES:
+`exhaustMap(project)` projects source values to an Observable, but ignores new source values while an inner Observable is still active. Ideal for preventing duplicate submissions.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `exhaustMap` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { exhaustMap } from "@observable/exhaust-map";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+import { timeout } from "@observable/timeout";
+import { map } from "@observable/map";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3]),  // Rapid clicks
+  exhaustMap((value) => pipe(
+    timeout(100),
+    map(() => value)
+  ))
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // Only: 1
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+PREVENT DOUBLE-SUBMIT:
+```ts
+pipe(
+  submitButton,
+  exhaustMap(() => saveForm())  // Ignores clicks while saving
+).subscribe({
+  next: () => console.log("Saved!"),
+  ...
+});
+```
+
+BEHAVIOR:
+- First source value starts an inner Observable
+- While inner Observable is active, new source values are ignored
+- After inner Observable returns, next source value is processed
+
+SEE ALSO:
+- `switchMap` — cancels previous inner Observable when new value arrives
+- `mergeMap` — subscribes to all inner Observables concurrently
+- `flatMap` — subscribes to inner Observables sequentially
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/exhaust-map/deno.json
+++ b/exhaust-map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/exhaust-map",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/filter/README.md
+++ b/filter/README.md
@@ -37,6 +37,56 @@ pipe(of([1, 2, 3, 4, 5]), filter((value) => value % 2 === 0)).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/filter from the @observable library ecosystem.
+
+WHAT IT DOES:
+`filter()` only emits values from the source that satisfy the specified predicate function.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- `filter` is a standalone function used with `pipe()` — NOT a method on Observable
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+
+USAGE PATTERN:
+```ts
+import { filter } from "@observable/filter";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3, 4, 5]),
+  filter((value) => value % 2 === 0)
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 2, 4
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+WRONG USAGE:
+```ts
+// ✗ WRONG: filter is NOT a method on Observable
+of([1, 2, 3]).filter(x => x > 1)  // This does NOT work!
+```
+
+TYPE NARROWING:
+The predicate can be a type guard for type narrowing:
+```ts
+pipe(
+  of([1, "a", 2, "b"]),
+  filter((x): x is number => typeof x === "number"),
+).subscribe({ ... });  // TypeScript knows values are numbers
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/filter/deno.json
+++ b/filter/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/filter",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/finalize/README.md
+++ b/finalize/README.md
@@ -44,6 +44,72 @@ pipe(of([1, 2, 3]), finalize(() => console.log("finalized"))).subscribe({
 // "finalized"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/finalize from the @observable library ecosystem.
+
+WHAT IT DOES:
+`finalize(callback)` calls the callback when the subscription ends for ANY reason — `return()`, `throw()`, or unsubscription via `abort()`. Always runs as a side-effect AFTER the terminal event.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `finalize` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { finalize } from "@observable/finalize";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3]),
+  finalize(() => console.log("finalized"))
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  return: () => console.log("return"),
+  throw: (error) => console.error("throw", error),
+});
+// Output:
+// 1
+// 2
+// 3
+// "return"
+// "finalized"
+```
+
+CLEANUP ON UNSUBSCRIPTION:
+```ts
+pipe(
+  interval(1000),
+  finalize(() => console.log("Cleaned up!"))
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  ...
+});
+
+controller.abort();  // Triggers: "Cleaned up!"
+```
+
+COMMON USE — Resource cleanup:
+```ts
+pipe(
+  webSocketConnection,
+  finalize(() => {
+    console.log("Closing connection...");
+    socket.close();
+  })
+).subscribe({ ... });
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/finalize/deno.json
+++ b/finalize/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/finalize",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/flat-map/README.md
+++ b/flat-map/README.md
@@ -54,6 +54,62 @@ pipe(source, flatMap((value) => observableLookup[value])).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/flat-map from the @observable library ecosystem.
+
+WHAT IT DOES:
+`flatMap(project)` projects each source value to an Observable and subscribes to them sequentially — waiting for each inner Observable to return before subscribing to the next. Also known as `concatMap` in RxJS.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `flatMap` is a standalone function used with `pipe()` — NOT a method on Observable
+- This is called `flatMap` (like `concatMap` in RxJS), NOT `flatMap` from RxJS which is `mergeMap`
+
+USAGE PATTERN:
+```ts
+import { flatMap } from "@observable/flat-map";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+const lookup = {
+  a: of([1, 2, 3]),
+  b: of([4, 5, 6]),
+  c: of([7, 8, 9]),
+};
+
+pipe(
+  of(["a", "b", "c"]),
+  flatMap((key) => lookup[key])
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1, 2, 3, 4, 5, 6, 7, 8, 9
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+SEQUENTIAL EXECUTION:
+Each inner Observable returns before the next one starts:
+```ts
+pipe(
+  of(["file1", "file2", "file3"]),
+  flatMap((file) => uploadFile(file))  // Uploads one at a time
+).subscribe({ ... });
+```
+
+SEE ALSO:
+- `mergeMap` — subscribes to all inner Observables concurrently
+- `switchMap` — cancels previous inner Observable when new value arrives
+- `exhaustMap` — ignores new values while inner Observable is active
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/flat-map/deno.json
+++ b/flat-map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/flat-map",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/flat/README.md
+++ b/flat/README.md
@@ -45,6 +45,56 @@ flat([of([1, 2, 3]), of([4, 5, 6]), of([7, 8, 9])]).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/flat from the @observable library ecosystem.
+
+WHAT IT DOES:
+`flat(sources)` creates an Observable that sequentially emits all values from the first source, then moves to the next source, and so on. Similar to RxJS `concat`.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- Called `flat` here, similar to RxJS's `concat`
+
+USAGE PATTERN:
+```ts
+import { flat } from "@observable/flat";
+import { of } from "@observable/of";
+
+const controller = new AbortController();
+
+flat([
+  of([1, 2, 3]),
+  of([4, 5, 6]),
+  of([7, 8, 9])
+]).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1, 2, 3, 4, 5, 6, 7, 8, 9
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+SEQUENTIAL BEHAVIOR:
+- Subscribes to the first source
+- Waits for it to return
+- Then subscribes to the next source
+- Repeats until all sources return
+
+USE CASES:
+- Ordered sequences that must run in order
+- Startup initialization sequences
+- Chaining async operations
+
+SEE ALSO:
+- `merge` — emits from all sources concurrently (interleaved)
+- `flatMap` — like flat but projects each value to an Observable first
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/flat/deno.json
+++ b/flat/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/flat",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/ignore-elements/README.md
+++ b/ignore-elements/README.md
@@ -35,6 +35,62 @@ pipe(of([1, 2, 3, 4, 5]), ignoreElements()).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/ignore-elements from the @observable library ecosystem.
+
+WHAT IT DOES:
+`ignoreElements()` ignores all emitted values from the source, only forwarding `return()` or `throw()`. Useful when you only care about when the source returns or throws.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `ignoreElements` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { ignoreElements } from "@observable/ignore-elements";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3, 4, 5]),
+  ignoreElements()
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // Never called
+  return: () => console.log("done"),    // Called when source returns
+  throw: (error) => console.error(error),
+});
+// Output: "done"
+```
+
+COMMON USE — Wait for return:
+```ts
+pipe(
+  saveAllData,
+  ignoreElements()
+).subscribe({
+  return: () => console.log("All saves finished!"),
+  throw: (error) => console.error("Save failed:", error),
+  ...
+});
+```
+
+COMMON USE — Side-effect only subscriptions:
+```ts
+pipe(
+  loggingObservable,
+  ignoreElements()
+).subscribe({ ... });  // Just run the side effects
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/ignore-elements/deno.json
+++ b/ignore-elements/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/ignore-elements",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/internal/deno.json
+++ b/internal/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/internal",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/interval/README.md
+++ b/interval/README.md
@@ -64,6 +64,61 @@ interval(0).subscribe({
 // "next" 2
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/interval from the @observable library ecosystem.
+
+WHAT IT DOES:
+`interval(ms)` creates an Observable that emits sequential integers (0, 1, 2, ...) at the specified interval. Never returns on its own — use operators like `take()` to limit.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+
+USAGE PATTERN:
+```ts
+import { interval } from "@observable/interval";
+import { take } from "@observable/take";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  interval(1000),  // Emit every 1 second
+  take(3)          // Take only 3 values
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 0, 1, 2 (one per second)
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+EDGE CASE — 0ms INTERVAL:
+```ts
+// 0ms interval emits synchronously
+interval(0).subscribe({
+  signal: controller.signal,
+  next: (value) => {
+    console.log(value);
+    if (value === 2) controller.abort();  // Stop at 2
+  },
+  ...
+});
+// Immediately logs: 0, 1, 2
+```
+
+REMEMBER:
+- `interval` never returns — always use `take()`, `takeUntil()`, or `abort()` to stop
+- First emission is AFTER the interval (not immediately)
+
+SEE ALSO:
+- `timeout(ms)` — emits once after delay, then returns
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/interval/deno.json
+++ b/interval/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/interval",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/keep-alive/README.md
+++ b/keep-alive/README.md
@@ -40,6 +40,60 @@ pipe(of([1, 2, 3]), keepAlive()).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/keep-alive from the @observable library ecosystem.
+
+WHAT IT DOES:
+`keepAlive()` ignores unsubscription signals (`abort()`), keeping the source subscription alive until the source naturally returns or throws.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `keepAlive` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { keepAlive } from "@observable/keep-alive";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3]),
+  keepAlive()
+).subscribe({
+  signal: controller.signal,
+  next: (value) => {
+    console.log(value);
+    if (value === 2) controller.abort();  // Ignored!
+  },
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+// Output: 1, 2, 3, "done"
+// Note: abort() at value 2 was ignored
+```
+
+WARNING:
+Use with caution! This prevents normal cleanup:
+- `controller.abort()` has no effect
+- Subscription continues until source returns
+- Could cause memory leaks if source never returns
+
+COMMON USE — Critical operations:
+```ts
+pipe(
+  criticalSaveOperation,
+  keepAlive()  // Don't interrupt mid-save
+).subscribe({ ... });
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/keep-alive/deno.json
+++ b/keep-alive/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/keep-alive",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/map/README.md
+++ b/map/README.md
@@ -38,6 +38,56 @@ pipe(of([1, 2, 3]), map((value) => value * 2)).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/map from the @observable library ecosystem.
+
+WHAT IT DOES:
+`map()` projects each value from the source Observable to a new value using a projection function.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- `map` is a standalone function used with `pipe()` — NOT a method on Observable
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+
+USAGE PATTERN:
+```ts
+import { map } from "@observable/map";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3]),
+  map((value) => value * 2)
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 2, 4, 6
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+WRONG USAGE:
+```ts
+// ✗ WRONG: map is NOT a method on Observable
+of([1, 2, 3]).map(x => x * 2)  // This does NOT work!
+```
+
+CHAINING WITH OTHER OPERATORS:
+```ts
+pipe(
+  of([1, 2, 3, 4, 5]),
+  filter((x) => x % 2 === 0),
+  map((x) => x * 10),
+).subscribe({ ... });  // 20, 40
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/map/deno.json
+++ b/map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/map",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/materialize/README.md
+++ b/materialize/README.md
@@ -80,6 +80,74 @@ describe("observable", () => {
 });
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/materialize from the @observable library ecosystem.
+
+WHAT IT DOES:
+`materialize()` converts all notifications (next, return, throw) into `next` emissions as tagged tuples. Useful for testing, debugging, and logging.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `materialize` is a standalone function used with `pipe()` — NOT a method on Observable
+
+NOTIFICATION FORMAT:
+- `["next", value]` — for emitted values
+- `["return"]` — for return (successful finish)
+- `["throw", error]` — for errors
+
+USAGE PATTERN:
+```ts
+import { materialize } from "@observable/materialize";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3]),
+  materialize()
+).subscribe({
+  signal: controller.signal,
+  next: (notification) => console.log(notification),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+// Output:
+// ["next", 1]
+// ["next", 2]
+// ["next", 3]
+// ["return"]
+// "done"
+```
+
+TESTING EXAMPLE:
+```ts
+import { materialize, ObserverNotification } from "@observable/materialize";
+import { Observer } from "@observable/core";
+
+const notifications: Array<ObserverNotification<number>> = [];
+
+pipe(observable, materialize()).subscribe(
+  new Observer({
+    signal: controller.signal,
+    next: (notification) => notifications.push(notification),
+  })
+);
+
+expect(notifications).toEqual([
+  ["next", 1],
+  ["next", 2],
+  ["next", 3],
+  ["return"],
+]);
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/materialize/deno.json
+++ b/materialize/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/materialize",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/merge-map/README.md
+++ b/merge-map/README.md
@@ -53,6 +53,66 @@ pipe(
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/merge-map from the @observable library ecosystem.
+
+WHAT IT DOES:
+`mergeMap(project)` projects each source value to an Observable and subscribes to all of them concurrently, merging their emissions into the output.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `mergeMap` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { mergeMap } from "@observable/merge-map";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+const lookup = {
+  1: of([1, 2, 3]),
+  2: of([4, 5, 6]),
+  3: of([7, 8, 9]),
+};
+
+pipe(
+  of([1, 2, 3]),
+  mergeMap((key) => lookup[key])
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1, 2, 3, 4, 5, 6, 7, 8, 9
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+CONCURRENT EXECUTION:
+All inner Observables run at the same time:
+```ts
+pipe(
+  of(["url1", "url2", "url3"]),
+  mergeMap((url) => fetchData(url))  // All requests fire immediately
+).subscribe({ ... });
+```
+
+WHEN TO USE:
+- When order doesn't matter and you want maximum parallelism
+- Fire-and-forget operations
+- Independent async tasks
+
+SEE ALSO:
+- `flatMap` — subscribes to inner Observables sequentially (one at a time)
+- `switchMap` — cancels previous inner Observable when new value arrives
+- `exhaustMap` — ignores new values while inner Observable is active
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/merge-map/deno.json
+++ b/merge-map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/merge-map",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/merge/README.md
+++ b/merge/README.md
@@ -45,6 +45,57 @@ source2.return();
 source3.return(); // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/merge from the @observable library ecosystem.
+
+WHAT IT DOES:
+`merge(sources)` creates an Observable that concurrently emits all values from every given source Observable. Returns when all sources return.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `merge` takes an array of Observables — check API for exact signature
+
+USAGE PATTERN:
+```ts
+import { merge } from "@observable/merge";
+import { Subject } from "@observable/core";
+
+const controller = new AbortController();
+const source1 = new Subject<number>();
+const source2 = new Subject<number>();
+const source3 = new Subject<number>();
+
+merge([source1, source2, source3]).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+
+source1.next(1);  // logs: 1
+source2.next(2);  // logs: 2
+source3.next(3);  // logs: 3
+source1.next(4);  // logs: 4
+source1.return();
+source2.return();
+source3.return();  // logs: "done" (when ALL return)
+```
+
+RETURN BEHAVIOR:
+- Emits values from all sources as they arrive
+- Only calls `return()` when ALL sources have returned
+- If any source throws, the merged Observable throws
+
+SEE ALSO:
+- `race` — mirrors only the first source to emit
+- `all` — emits arrays of latest values from all sources
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/merge/deno.json
+++ b/merge/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/merge",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/never/README.md
+++ b/never/README.md
@@ -31,6 +31,60 @@ never.subscribe({
 });
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/never from the @observable library ecosystem.
+
+WHAT IT DOES:
+`never` is an Observable constant that does nothing — never emits values, never returns, never throws. Subscription stays open indefinitely until aborted.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `never` is a constant, not a function — use as `never` not `never()`
+
+USAGE PATTERN:
+```ts
+import { never } from "@observable/never";
+
+const controller = new AbortController();
+
+never.subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),    // Never called
+  return: () => console.log("done"),       // Never called
+  throw: (error) => console.error(error), // Never called
+});
+
+// Only way to end the subscription:
+controller.abort();
+```
+
+COMMON USE — Testing infinite streams:
+```ts
+import { race } from "@observable/race";
+import { timeout } from "@observable/timeout";
+
+// Test that something wins against never
+race([
+  someObservable,
+  never
+]).subscribe({ ... });  // Will only emit if someObservable emits
+```
+
+COMMON USE — Keep-alive placeholder:
+```ts
+const observable = condition ? actualObservable : never;
+```
+
+SEE ALSO:
+- `empty` — returns immediately without emitting
+- `throwError(value)` — immediately throws an error
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/never/deno.json
+++ b/never/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/never",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/of/README.md
+++ b/of/README.md
@@ -62,6 +62,61 @@ of([1, 2, 3]).subscribe({
 // "next" 2
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/of from the @observable library ecosystem.
+
+WHAT IT DOES:
+`of()` creates an Observable that emits values from an Iterable in order, then calls `return()`.
+
+CRITICAL DIFFERENCES FROM RxJS:
+- Takes a SINGLE Iterable argument — NOT variadic arguments
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+
+CORRECT USAGE:
+```ts
+import { of } from "@observable/of";
+
+const controller = new AbortController();
+
+// ✓ CORRECT: Pass an array (Iterable)
+of([1, 2, 3]).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1, 2, 3
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+
+// ✓ Also works with any Iterable
+of(new Set([1, 2, 3])).subscribe({ ... });
+of("abc").subscribe({ ... });  // 'a', 'b', 'c'
+```
+
+WRONG USAGE:
+```ts
+// ✗ WRONG: Variadic arguments don't work like RxJS
+of(1, 2, 3)  // This does NOT work!
+```
+
+EARLY UNSUBSCRIPTION:
+```ts
+const controller = new AbortController();
+of([1, 2, 3]).subscribe({
+  signal: controller.signal,
+  next(value) {
+    console.log(value);
+    if (value === 2) controller.abort();  // Stops after 2
+  },
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/of/deno.json
+++ b/of/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/of",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/pairwise/README.md
+++ b/pairwise/README.md
@@ -38,6 +38,60 @@ pipe(of([1, 2, 3, 4]), pairwise()).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/pairwise from the @observable library ecosystem.
+
+WHAT IT DOES:
+`pairwise()` emits pairs of consecutive values as arrays `[previous, current]`. Skips the first value since there's no previous value to pair with.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `pairwise` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { pairwise } from "@observable/pairwise";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3, 4]),
+  pairwise()
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+// Output:
+// [1, 2]
+// [2, 3]
+// [3, 4]
+// "done"
+```
+
+BEHAVIOR:
+- First emission requires 2 source values
+- Each subsequent emission slides the window by 1
+- Useful for computing deltas or transitions
+
+COMMON USE — Compute differences:
+```ts
+pipe(
+  scrollPosition,
+  pairwise(),
+  map(([prev, curr]) => curr - prev)  // Scroll delta
+).subscribe({ ... });
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/pairwise/deno.json
+++ b/pairwise/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/pairwise",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/pipe/README.md
+++ b/pipe/README.md
@@ -44,6 +44,49 @@ pipe(
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/pipe from the @observable library ecosystem.
+
+WHAT IT DOES:
+`pipe()` is a utility that pipes a value through a series of unary functions. It's the core composition mechanism for building observation chains with operators.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- Operators are standalone functions — NOT methods on Observable
+
+USAGE PATTERN:
+```ts
+import { pipe } from "@observable/pipe";
+import { of } from "@observable/of";
+import { map } from "@observable/map";
+import { filter } from "@observable/filter";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3, 4, 5]),
+  filter((value) => value % 2 === 0),
+  map((value) => value * 2),
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+KEY POINTS:
+- First argument is the initial value (typically an Observable)
+- Subsequent arguments are operator functions
+- Returns the result of piping through all functions
+- Essential for composing operators in this library
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/pipe/deno.json
+++ b/pipe/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/pipe",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/race/README.md
+++ b/race/README.md
@@ -45,6 +45,55 @@ source3.next(5);
 source2.return(); // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/race from the @observable library ecosystem.
+
+WHAT IT DOES:
+`race(sources)` creates an Observable that mirrors the first source Observable to emit or throw a value. All other sources are unsubscribed once a winner is determined.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `race` takes an array of Observables
+
+USAGE PATTERN:
+```ts
+import { race } from "@observable/race";
+import { Subject } from "@observable/core";
+
+const controller = new AbortController();
+const source1 = new Subject<number>();
+const source2 = new Subject<number>();
+const source3 = new Subject<number>();
+
+race([source1, source2, source3]).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+
+source2.next(1);  // logs: 1 — source2 wins!
+source1.next(2);  // (ignored — source1 lost)
+source3.next(3);  // (ignored — source3 lost)
+source2.next(4);  // logs: 4 — continuing with winner
+source2.return(); // logs: "done"
+```
+
+USE CASES:
+- Timeout patterns (race between data and timeout)
+- First-response-wins from multiple sources
+- Fallback strategies
+
+SEE ALSO:
+- `merge` — emits from all sources concurrently
+- `all` — combines latest values from all sources
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/race/deno.json
+++ b/race/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/race",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/repeat/README.md
+++ b/repeat/README.md
@@ -67,6 +67,54 @@ repeated.subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/repeat from the @observable library ecosystem.
+
+WHAT IT DOES:
+`repeat(notifier)` re-subscribes to the source Observable each time it returns, as long as the notifier Observable emits a value. Stops repeating if the notifier returns without emitting or throws.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `repeat` is a standalone function used with `pipe()` — NOT a method on Observable
+- Uses a notifier Observable to control repetition
+
+USAGE PATTERN:
+```ts
+import { repeat } from "@observable/repeat";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+import { defer } from "@observable/defer";
+import { empty } from "@observable/empty";
+
+const source = of([1, 2, 3]);
+const controller = new AbortController();
+
+let count = 0;
+pipe(
+  source,
+  repeat(defer(() => {
+    return ++count < 3 ? of([undefined]) : empty;
+  }))
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+// Output: 1, 2, 3, 1, 2, 3, "done"
+```
+
+NOTIFIER BEHAVIOR:
+- Notifier emits `next()` → source re-subscribes
+- Notifier calls `return()` without emitting → stop repeating, return
+- Notifier calls `throw()` → stop repeating, propagate error
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/repeat/deno.json
+++ b/repeat/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/repeat",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/replay-subject/deno.json
+++ b/replay-subject/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/replay-subject",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/rxjs-interop/README.md
+++ b/rxjs-interop/README.md
@@ -59,6 +59,67 @@ const subscription = observable.subscribe({
 // "complete"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/rxjs-interop from the @observable library ecosystem.
+
+WHAT IT DOES:
+Provides utilities to convert between RxJS Observables and @observable Observables in both directions.
+
+KEY DIFFERENCES BETWEEN THE LIBRARIES:
+- @observable uses `return`/`throw` — RxJS uses `complete`/`error`
+- @observable uses `AbortController` — RxJS uses `Subscription`
+- @observable's `of()` takes an Iterable — RxJS's `of()` takes variadic args
+
+USAGE — RxJS to @observable:
+```ts
+import { asObservable } from "@observable/rxjs-interop";
+import { of as rxJsOf } from "rxjs";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  rxJsOf(1, 2, 3),  // RxJS Observable (variadic of)
+  asObservable()    // Convert to @observable
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1, 2, 3
+  return: () => console.log("done"),    // Maps from RxJS complete
+  throw: (error) => console.error(error), // Maps from RxJS error
+});
+```
+
+USAGE — @observable to RxJS:
+```ts
+import { asRxJsObservable } from "@observable/rxjs-interop";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const rxjsObservable = pipe(
+  of([1, 2, 3]),      // @observable Observable (Iterable of)
+  asRxJsObservable()  // Convert to RxJS
+);
+
+// Now use RxJS patterns
+const subscription = rxjsObservable.subscribe({
+  next: (value) => console.log(value),  // 1, 2, 3
+  complete: () => console.log("complete"), // Maps from return
+  error: (error) => console.error(error),   // Maps from throw
+});
+
+subscription.unsubscribe();  // RxJS unsubscription
+```
+
+MAPPING:
+- `return()` ↔ `complete()`
+- `throw()` ↔ `error()`
+- `controller.abort()` ↔ `subscription.unsubscribe()`
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/rxjs-interop/deno.json
+++ b/rxjs-interop/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/rxjs-interop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] },

--- a/share/README.md
+++ b/share/README.md
@@ -53,6 +53,68 @@ shared.subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/share from the @observable library ecosystem.
+
+WHAT IT DOES:
+`share()` multicasts a source Observable through a Subject, sharing a single subscription among multiple subscribers. Resets when all subscribers unsubscribe or when the source returns/throws.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `share` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { share } from "@observable/share";
+import { timeout } from "@observable/timeout";
+import { pipe } from "@observable/pipe";
+
+const shared = pipe(timeout(1_000), share());
+const controller = new AbortController();
+
+// Both subscribers share the same source subscription
+shared.subscribe({
+  signal: controller.signal,
+  next: (value) => console.log("A:", value),
+  return: () => console.log("A done"),
+  throw: (error) => console.error("A error:", error),
+});
+
+shared.subscribe({
+  signal: controller.signal,
+  next: (value) => console.log("B:", value),
+  return: () => console.log("B done"),
+  throw: (error) => console.error("B error:", error),
+});
+
+// After 1 second:
+// "A:" 0
+// "B:" 0
+// "A done"
+// "B done"
+```
+
+HOT VS COLD:
+- Without `share()`: Each subscriber creates a new subscription (cold)
+- With `share()`: All subscribers share one subscription (hot)
+
+RESET BEHAVIOR:
+The shared subscription resets when:
+- All subscribers unsubscribe
+- The source returns (`return()`)
+- The source throws (`throw()`)
+
+SEE ALSO:
+- `Subject` — for manual multicasting
+- `BehaviorSubject` — for multicasting with current value
+- `ReplaySubject` — for multicasting with value replay
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/share/deno.json
+++ b/share/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/share",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/switch-map/README.md
+++ b/switch-map/README.md
@@ -46,6 +46,66 @@ pipe(of([1, 2, 3]), switchMap((value) => observableLookup[value])).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/switch-map from the @observable library ecosystem.
+
+WHAT IT DOES:
+`switchMap(project)` projects each source value to an Observable, subscribing to only the most recent inner Observable and canceling previous ones. Ideal for search-as-you-type, route changes, etc.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `switchMap` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { switchMap } from "@observable/switch-map";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3]),
+  switchMap((id) => fetchUser(id))  // Only latest request matters
+).subscribe({
+  signal: controller.signal,
+  next: (user) => console.log(user),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+CANCELLATION BEHAVIOR:
+When a new source value arrives, the previous inner Observable is automatically unsubscribed:
+```ts
+pipe(
+  searchInput,
+  debounce(300),
+  switchMap((query) => searchApi(query))  // Previous search canceled
+).subscribe({ ... });
+```
+
+SYNCHRONOUS EXAMPLE:
+```ts
+const lookup = { 1: of([1, 2, 3]), 2: of([4, 5, 6]), 3: of([7, 8, 9]) };
+pipe(
+  of([1, 2, 3]),
+  switchMap((key) => lookup[key])
+).subscribe({ ... });
+// Only emits: 7, 8, 9 (from the last Observable)
+```
+
+SEE ALSO:
+- `mergeMap` — subscribes to all inner Observables concurrently
+- `flatMap` — subscribes to inner Observables sequentially
+- `exhaustMap` — ignores new values while inner Observable is active
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/switch-map/deno.json
+++ b/switch-map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/switch-map",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/take-until/README.md
+++ b/take-until/README.md
@@ -43,6 +43,62 @@ source.next(3);
 source.return();
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/take-until from the @observable library ecosystem.
+
+WHAT IT DOES:
+`takeUntil(notifier)` takes values from the source until the notifier Observable emits a value.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `takeUntil` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { Subject } from "@observable/core";
+import { takeUntil } from "@observable/take-until";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+const source = new Subject<number>();
+const notifier = new Subject<void>();
+
+pipe(
+  source,
+  takeUntil(notifier)
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+
+source.next(1);  // logs: 1
+source.next(2);  // logs: 2
+notifier.next(); // logs: "done" — subscription returns
+source.next(3);  // not logged
+```
+
+COMMON USE CASE — Component Destruction:
+```ts
+const destroy = new Subject<void>();
+
+pipe(
+  someObservable,
+  takeUntil(destroy)
+).subscribe({ ... });
+
+// When component/resource is destroyed:
+destroy.next();
+destroy.return();
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/take-until/deno.json
+++ b/take-until/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/take-until",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/take/README.md
+++ b/take/README.md
@@ -37,6 +37,55 @@ pipe(of([1, 2, 3, 4, 5]), take(2)).subscribe({
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/take from the @observable library ecosystem.
+
+WHAT IT DOES:
+`take(count)` takes only the first `count` values from the source Observable, then calls `return()`.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `take` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { take } from "@observable/take";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3, 4, 5]),
+  take(2)
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1, 2
+  return: () => console.log("done"),    // Called after 2 values
+  throw: (error) => console.error(error),
+});
+```
+
+USE WITH INFINITE STREAMS:
+```ts
+import { interval } from "@observable/interval";
+
+pipe(
+  interval(1000),  // Emits 0, 1, 2, ... every second
+  take(3)          // Takes only first 3, then returns
+).subscribe({ ... });  // 0, 1, 2, then "done"
+```
+
+SEE ALSO:
+- `drop(count)` — skips first N values
+- `takeUntil(notifier)` — takes until notifier emits
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/take/deno.json
+++ b/take/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/take",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/tap/README.md
+++ b/tap/README.md
@@ -52,6 +52,65 @@ pipe(
 // "return"
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/tap from the @observable library ecosystem.
+
+WHAT IT DOES:
+`tap()` performs side-effects on the source Observable without modifying the values. Useful for debugging, logging, or triggering external actions.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `tap` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { tap } from "@observable/tap";
+import { of } from "@observable/of";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+
+pipe(
+  of([1, 2, 3]),
+  tap({
+    signal: controller.signal,
+    next: (value) => console.log("tapped:", value),
+    return: () => console.log("tap return"),
+    throw: (error) => console.error("tap error:", error),
+  }),
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log("received:", value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+TAP HAS ITS OWN SIGNAL:
+The tap observer can have its own AbortController, allowing you to stop tapping without stopping the subscription:
+```ts
+const tapController = new AbortController();
+const subscriptionController = new AbortController();
+
+pipe(
+  source,
+  tap({
+    signal: tapController.signal,  // Independent control
+    next: (value) => { if (value === 2) tapController.abort(); },
+  }),
+).subscribe({
+  signal: subscriptionController.signal,
+  next: (value) => console.log(value),  // Still receives all values
+  ...
+});
+```
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/tap/deno.json
+++ b/tap/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/tap",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/throttle/README.md
+++ b/throttle/README.md
@@ -47,6 +47,51 @@ source.next(4); // Emitted after throttle window
 // "next" 4
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/throttle from the @observable library ecosystem.
+
+WHAT IT DOES:
+`throttle(ms)` emits the first value immediately, then ignores subsequent values for `ms` milliseconds. Useful for rate-limiting scroll events, button clicks, etc.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- `throttle` is a standalone function used with `pipe()` — NOT a method on Observable
+
+USAGE PATTERN:
+```ts
+import { throttle } from "@observable/throttle";
+import { Subject } from "@observable/core";
+import { pipe } from "@observable/pipe";
+
+const controller = new AbortController();
+const scroll = new Subject<number>();
+
+pipe(
+  scroll,
+  throttle(100)  // At most one emission per 100ms
+).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log("scroll position:", value),
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+
+scroll.next(10);  // logs: 10 (immediately)
+scroll.next(20);  // (ignored — within 100ms window)
+scroll.next(30);  // (ignored — within 100ms window)
+// After 100ms...
+scroll.next(40);  // logs: 40
+```
+
+SEE ALSO:
+- `debounce(ms)` — waits for silence before emitting
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/throttle/deno.json
+++ b/throttle/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/throttle",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/throw-error/README.md
+++ b/throw-error/README.md
@@ -32,6 +32,69 @@ throwError(new Error("throw")).subscribe({
 });
 ```
 
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/throw-error from the @observable library ecosystem.
+
+WHAT IT DOES:
+`throwError(value)` creates an Observable that immediately calls `throw()` with the given value on subscribe. No values are emitted.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+
+USAGE PATTERN:
+```ts
+import { throwError } from "@observable/throw-error";
+
+const controller = new AbortController();
+
+throwError(new Error("Something went wrong")).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),    // Never called
+  return: () => console.log("done"),       // Never called
+  throw: (error) => console.error(error), // Called immediately
+});
+// Output: Error: Something went wrong
+```
+
+COMMON USE — Conditional errors:
+```ts
+import { pipe } from "@observable/pipe";
+import { flatMap } from "@observable/flat-map";
+
+pipe(
+  of([userId]),
+  flatMap((id) =>
+    id ? fetchUser(id) : throwError(new Error("User ID required"))
+  )
+).subscribe({ ... });
+```
+
+COMMON USE — Re-throwing in catchError:
+```ts
+import { catchError } from "@observable/catch-error";
+
+pipe(
+  someObservable,
+  catchError((error) => {
+    if (isRecoverable(error)) {
+      return fallbackObservable;
+    }
+    return throwError(error);  // Re-throw
+  })
+).subscribe({ ... });
+```
+
+SEE ALSO:
+- `empty` — returns immediately without emitting
+- `never` — never emits and never returns
+- `catchError` — catches thrown errors
+````
+
 # Glossary And Semantics
 
 [@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/throw-error/deno.json
+++ b/throw-error/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/throw-error",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/timeout/README.md
+++ b/timeout/README.md
@@ -36,7 +36,7 @@ timeout(1_000).subscribe({
 // "return"
 ```
 
-## Synchronous completion with 0ms
+## Synchronous return with 0ms
 
 ```ts
 import { timeout } from "@observable/timeout";
@@ -72,6 +72,66 @@ timeout(-1).subscribe({
 // Console output (synchronously):
 // "return"
 ```
+
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/timeout from the @observable library ecosystem.
+
+WHAT IT DOES:
+`timeout(ms)` creates an Observable that emits `0` after the specified delay, then returns. Like a single-shot timer.
+
+CRITICAL: This library is NOT RxJS. Key differences:
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+- This `timeout` creates a timer — different from RxJS `timeout` which throws on delay
+
+USAGE PATTERN:
+```ts
+import { timeout } from "@observable/timeout";
+
+const controller = new AbortController();
+
+timeout(1_000).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 0 (after 1 second)
+  return: () => console.log("done"),    // Called after emission
+  throw: (error) => console.error(error),
+});
+```
+
+EDGE CASES:
+```ts
+// 0ms timeout emits synchronously
+timeout(0).subscribe({ ... });  // Emits 0 immediately
+
+// Negative values return immediately without emitting
+timeout(-1).subscribe({
+  next: (value) => console.log(value),  // Never called
+  return: () => console.log("done"),    // Called immediately
+  ...
+});
+```
+
+COMMON USE — Delay an action:
+```ts
+import { map } from "@observable/map";
+import { pipe } from "@observable/pipe";
+
+pipe(
+  timeout(500),
+  map(() => "delayed value")
+).subscribe({
+  next: (value) => console.log(value),  // "delayed value" after 500ms
+  ...
+});
+```
+
+SEE ALSO:
+- `interval(ms)` — emits repeatedly at interval
+````
 
 # Glossary And Semantics
 

--- a/timeout/deno.json
+++ b/timeout/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/timeout",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }


### PR DESCRIPTION
…les (#36)

* Incremented version numbers in deno.json files for various modules, including @observable/all to 0.3.0, @observable/as-async-iterable to 0.2.0, @observable/as-promise to 0.5.0, and others.
* Expanded documentation with AI prompts for better guidance on using the library, including examples and use cases for various operators and modules.
* Added new sections to README files to clarify behavior and provide practical examples for consumers.