### PR TITLE
Update versions for distinct-until-changed and pairwise modules; refa…

### DIFF
--- a/distinct-until-changed/deno.json
+++ b/distinct-until-changed/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/distinct-until-changed",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/pairwise/deno.json
+++ b/pairwise/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/pairwise",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/pairwise/mod.ts
+++ b/pairwise/mod.ts
@@ -14,7 +14,7 @@ const noValue = Symbol("Flag indicating that no value has been emitted yet");
 /**
  * Object type that represents a pair of consecutive values.
  */
-export type Pair<Value> = Readonly<[previous: Value, current: Value]>;
+export type Pair<Value = unknown> = Readonly<[previous: Value, current: Value]>;
 
 /**
  * [`Next`](https://jsr.io/@observable/core/doc/~/Observer.next)s {@linkcode Pair|pair}s of consecutive values


### PR DESCRIPTION
…ctor pairwise implementation to use scan operator (#49)

* Incremented version number for `@observable/distinct-until-changed` to 0.7.0 and `@observable/pairwise` to 0.6.0.
* Refactored the `pairwise` operator to utilize the `scan` operator for improved performance and clarity, replacing the previous implementation that used `filter` and `map`.
* Updated type definitions in `pairwise` to enhance type safety and readability.