### PR TITLE
Enhance documentation and update parameter naming conventions across …

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,44 @@ Functions should be pure wherever possible:
 - **No side effects** — No mutations, I/O, or external state changes
 - **Referentially transparent** — Can be replaced with its return value
 
+### Function Parameter Naming
+
+Function parameters should use descriptive names that convey their role. The following conventions
+are preferred (but not strictly enforced):
+
+| Name           | Purpose                                        | Signature                            |
+| -------------- | ---------------------------------------------- | ------------------------------------ |
+| **predicate**  | Tests a condition, returns boolean             | `(value) => boolean`                 |
+| **project**    | Transforms an input value into an output       | `(value) => newValue`                |
+| **reducer**    | Accumulates values over time                   | `(previous, current) => accumulated` |
+| **comparator** | Compares two values for equality               | `(a, b) => boolean`                  |
+| **callback**   | Called for side effects, returns void          | `(value) => void`                    |
+| **factory**    | Zero-argument function that produces something | `() => something`                    |
+
+```ts
+// predicate — "should this pass through?"
+filter((x) => x > 5);
+
+// project — "transform this into that"
+map((x) => x * 2);
+switchMap((id) => fetchUser(id));
+
+// reducer — "combine previous + current"
+scan((total, value) => total + value, 0);
+
+// comparator — "are these the same?"
+distinctUntilChanged((a, b) => a.id === b.id);
+
+// callback — "do something with each value"
+forEach((value) => console.log(value));
+
+// factory — "create something on demand"
+defer(() => of([Date.now()]));
+
+// notifier — "signal me when to stop"
+takeUntil(destroy);
+```
+
 ### Documentation
 
 All public APIs **must have JSDoc documentation** including:

--- a/catch-error/README.md
+++ b/catch-error/README.md
@@ -1,8 +1,9 @@
 # [@observable/catch-error](https://jsr.io/@observable/catch-error)
 
-Catches errors from the [source](https://jsr.io/@observable/core#source)
-[`Observable`](https://jsr.io/@observable/core/doc/~/Observable) and returns a new
-[`Observable`](https://jsr.io/@observable/core/doc/~/Observable) with the resolved value.
+Projects each [`throw`](https://jsr.io/@observable/core/doc/~/Observer.throw)n value from the
+[source](https://jsr.io/@observable/core#source)
+[`Observable`](https://jsr.io/@observable/core/doc/~/Observable) to a new
+[`Observable`](https://jsr.io/@observable/core/doc/~/Observable).
 
 ## Build
 

--- a/catch-error/deno.json
+++ b/catch-error/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/catch-error",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/catch-error/mod.ts
+++ b/catch-error/mod.ts
@@ -4,9 +4,10 @@ import { asObservable } from "@observable/as-observable";
 import { pipe } from "@observable/pipe";
 
 /**
- * Catches errors from the [source](https://jsr.io/@observable/core#source)
- * [`Observable`](https://jsr.io/@observable/core/doc/~/Observable) and returns a new
- * [`Observable`](https://jsr.io/@observable/core/doc/~/Observable) with the resolved value.
+ * {@linkcode project|Projects} each [`throw`](https://jsr.io/@observable/core/doc/~/Observer.throw)n
+ * value from the [source](https://jsr.io/@observable/core#source)
+ * [`Observable`](https://jsr.io/@observable/core/doc/~/Observable) to a new
+ * [`Observable`](https://jsr.io/@observable/core/doc/~/Observable).
  * @example
  * ```ts
  * import { catchError } from "@observable/catch-error";
@@ -30,11 +31,11 @@ import { pipe } from "@observable/pipe";
  * // "return"
  * ```
  */
-export function catchError<Value, ResolvedValue>(
-  handler: (value: unknown) => Observable<ResolvedValue>,
-): (source: Observable<Value>) => Observable<Value | ResolvedValue> {
+export function catchError<Value, ProjectedValue>(
+  project: (error: unknown) => Observable<ProjectedValue>,
+): (source: Observable<Value>) => Observable<Value | ProjectedValue> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
-  if (typeof handler !== "function") throw new ParameterTypeError(0, "Function");
+  if (typeof project !== "function") throw new ParameterTypeError(0, "Function");
   return function catchErrorFn(source) {
     if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
     if (!isObservable(source)) throw new ParameterTypeError(0, "Observable");
@@ -46,7 +47,7 @@ export function catchError<Value, ResolvedValue>(
         return: () => observer.return(),
         throw(value) {
           try {
-            pipe(handler(value), asObservable()).subscribe(observer);
+            pipe(project(value), asObservable()).subscribe(observer);
           } catch (error) {
             observer.throw(error);
           }

--- a/defer/README.md
+++ b/defer/README.md
@@ -1,7 +1,7 @@
 # [@observable/defer](https://jsr.io/@observable/defer)
 
-Calls an [`Observable`](https://jsr.io/@observable/core/doc/~/Observable) `connector` function for
-each [subscription](https://jsr.io/@observable/core#subscription).
+Creates a new [`Observable`](https://jsr.io/@observable/core/doc/~/Observable) for each
+[`subscribe`](https://jsr.io/@observable/core/doc/~/Observable.subscribe).
 
 ## Build
 

--- a/defer/deno.json
+++ b/defer/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/defer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/defer/mod.ts
+++ b/defer/mod.ts
@@ -4,8 +4,8 @@ import { pipe } from "@observable/pipe";
 import { MinimumArgumentsRequiredError, ParameterTypeError } from "@observable/internal";
 
 /**
- * Calls an [`Observable`](https://jsr.io/@observable/core/doc/~/Observable) {@linkcode connector} function
- * for each [subscription](https://jsr.io/@observable/core#subscription).
+ * {@linkcode factory|Creates} a new [`Observable`](https://jsr.io/@observable/core/doc/~/Observable)
+ * for each [`subscribe`](https://jsr.io/@observable/core/doc/~/Observable.subscribe).
  * @example
  * ```ts
  * import { defer } from "@observable/defer";
@@ -44,9 +44,9 @@ import { MinimumArgumentsRequiredError, ParameterTypeError } from "@observable/i
  * // "return"
  */
 export function defer<Value>(
-  connector: () => Observable<Value>,
+  factory: () => Observable<Value>,
 ): Observable<Value> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
-  if (typeof connector !== "function") throw new ParameterTypeError(0, "Function");
-  return new Observable((observer) => pipe(connector(), asObservable()).subscribe(observer));
+  if (typeof factory !== "function") throw new ParameterTypeError(0, "Function");
+  return new Observable((observer) => pipe(factory(), asObservable()).subscribe(observer));
 }

--- a/for-each/deno.json
+++ b/for-each/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/for-each",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/for-each/mod.ts
+++ b/for-each/mod.ts
@@ -4,7 +4,7 @@ import { MinimumArgumentsRequiredError, ParameterTypeError } from "@observable/i
 import { map } from "@observable/map";
 
 /**
- * Performs a {@linkcode next|side-effect} for each [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed value
+ * Performs a {@linkcode callback|side-effect} for each [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed value
  * from the [source](https://jsr.io/@observable/core#source) [`Observable`](https://jsr.io/@observable/core/doc/~/Observable).
  * @example
  * ```ts
@@ -36,17 +36,17 @@ import { map } from "@observable/map";
  * ```
  */
 export function forEach<Value>(
-  next: (value: Value, index: number) => void,
+  callback: (value: Value, index: number) => void,
 ): (source: Observable<Value>) => Observable<Value> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
-  if (typeof next !== "function") throw new ParameterTypeError(0, "Function");
+  if (typeof callback !== "function") throw new ParameterTypeError(0, "Function");
   return function forEachFn(source) {
     if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
     if (!isObservable(source)) throw new ParameterTypeError(0, "Observable");
     return pipe(
       source,
       map((value, index) => {
-        next(value, index);
+        callback(value, index);
         return value;
       }),
     );

--- a/reduce/README.md
+++ b/reduce/README.md
@@ -1,10 +1,9 @@
 # [@observable/reduce](https://jsr.io/@observable/reduce)
 
-Applies an `accumulator` function over each [source](https://jsr.io/@observable/core#source)
+Reduces the [source](https://jsrio/@observable/core#source)
 [`Observable`](https://jsr.io/@observable/core/doc/~/Observable)'s
-[`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed value, and
-[`next`](https://jsr.io/@observable/core/doc/~/Observer.next)s only the final accumulated value (if
-any) when the [source](https://jsr.io/@observable/core#source)
+[`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed values to a single value when the
+[source](https://jsr.io/@observable/core#source)
 [`Observable`](https://jsr.io/@observable/core/doc/~/Observable)
 [`return`](https://jsr.io/@observable/core/doc/~/Observer.return)s.
 

--- a/reduce/deno.json
+++ b/reduce/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/reduce",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/reduce/mod.ts
+++ b/reduce/mod.ts
@@ -8,12 +8,10 @@ import { AsyncSubject } from "@observable/async-subject";
 import { defer } from "@observable/defer";
 
 /**
- * Applies an {@linkcode accumulator} function over each
- * [source](https://jsr.io/@observable/core#source)
+ * {@linkcode reducer|Reduces} the [source](https://jsrio/@observable/core#source)
  * [`Observable`](https://jsr.io/@observable/core/doc/~/Observable)'s
- * [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed value,
- * and [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)s only
- * the final accumulated value (if any) when the [source](https://jsr.io/@observable/core#source)
+ * [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed values to a single
+ * value when the [source](https://jsr.io/@observable/core#source)
  * [`Observable`](https://jsr.io/@observable/core/doc/~/Observable)
  * [`return`](https://jsr.io/@observable/core/doc/~/Observer.return)s.
  * @example
@@ -37,15 +35,15 @@ import { defer } from "@observable/defer";
  * ```
  */
 export function reduce<In, Out>(
-  accumulator: (previous: Out, current: In, index: number) => Out,
+  reducer: (previous: Out, current: In, index: number) => Out,
   seed: Out,
 ): (source: Observable<In>) => Observable<Out> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
-  if (typeof accumulator !== "function") throw new ParameterTypeError(0, "Function");
+  if (typeof reducer !== "function") throw new ParameterTypeError(0, "Function");
   return function reduceFn(source) {
     if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
     if (!isObservable(source)) throw new ParameterTypeError(0, "Observable");
     source = pipe(source, asObservable());
-    return defer(() => pipe(source, scan(accumulator, seed), share(() => new AsyncSubject())));
+    return defer(() => pipe(source, scan(reducer, seed), share(() => new AsyncSubject())));
   };
 }

--- a/scan/README.md
+++ b/scan/README.md
@@ -1,9 +1,9 @@
 # [@observable/scan](https://jsr.io/@observable/scan)
 
-Applies an `accumulator` function over each [source](https://jsr.io/@observable/core#source)
+Reduces the [source](https://jsrio/@observable/core#source)
 [`Observable`](https://jsr.io/@observable/core/doc/~/Observable)'s
-[`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed value, and
-[`next`](https://jsr.io/@observable/core/doc/~/Observer.next)s each intermediate accumulated value.
+[`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed values to a single value, and
+[`next`](https://jsr.io/@observable/core/doc/~/Observer.next)s each intermediate reduced value.
 
 ## Build
 

--- a/scan/deno.json
+++ b/scan/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/scan",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/scan/mod.ts
+++ b/scan/mod.ts
@@ -6,12 +6,11 @@ import { pipe } from "@observable/pipe";
 import { map } from "@observable/map";
 
 /**
- * Applies an {@linkcode accumulator} function over each
- * [source](https://jsr.io/@observable/core#source)
+ * {@linkcode reducer|Reduces} the [source](https://jsrio/@observable/core#source)
  * [`Observable`](https://jsr.io/@observable/core/doc/~/Observable)'s
- * [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed value,
- * and [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)s each
- * intermediate accumulated value.
+ * [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed values to a single
+ * value, and [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)s each
+ * intermediate reduced value.
  * @example
  * ```ts
  * import { scan } from "@observable/scan";
@@ -35,11 +34,11 @@ import { map } from "@observable/map";
  * ```
  */
 export function scan<In, Out>(
-  accumulator: (previous: Out, current: In, index: number) => Out,
+  reducer: (previous: Out, current: In, index: number) => Out,
   seed: Out,
 ): (source: Observable<In>) => Observable<Out> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
-  if (typeof accumulator !== "function") throw new ParameterTypeError(0, "Function");
+  if (typeof reducer !== "function") throw new ParameterTypeError(0, "Function");
   return function scanFn(source) {
     if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
     if (!isObservable(source)) throw new ParameterTypeError(0, "Observable");
@@ -48,7 +47,7 @@ export function scan<In, Out>(
       let previous = seed;
       return pipe(
         source,
-        map((current, index) => previous = accumulator(previous, current, index)),
+        map((current, index) => previous = reducer(previous, current, index)),
       );
     });
   };

--- a/share/deno.json
+++ b/share/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/share",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }


### PR DESCRIPTION
…multiple modules

- Added guidelines for function parameter naming in the README, promoting descriptive names such as `predicate`, `project`, `reducer`, `comparator`, `callback`, `factory`, and `notifier`.
- Updated the `catchError`, `defer`, `forEach`, `reduce`, and `scan` operators to reflect the new parameter naming conventions, improving clarity and consistency in the codebase.
- Incremented version numbers for `@observable/catch-error`, `@observable/defer`, `@observable/for-each`, `@observable/reduce`, and `@observable/scan` to align with the changes made.