### PR TITLE
Update versions and integrate `of` operator across modules

### DIFF
--- a/async-subject/deno.json
+++ b/async-subject/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/async-subject",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/async-subject/mod.ts
+++ b/async-subject/mod.ts
@@ -5,7 +5,7 @@ import {
   ParameterTypeError,
 } from "@observable/internal";
 import { flat } from "@observable/flat";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 import { switchMap } from "@observable/switch-map";
 import { drop } from "@observable/drop";
@@ -77,7 +77,7 @@ export const AsyncSubject: AsyncSubjectConstructor = class<Value> {
   readonly signal = this.#subject.signal;
   readonly #observable = pipe(
     this.#subject,
-    switchMap((value) => flat([pipe(this.#subject, drop<never>(Infinity)), forOf([value])])),
+    switchMap((value) => flat([pipe(this.#subject, drop<never>(Infinity)), of(value)])),
   );
 
   constructor() {

--- a/catch-error/README.md
+++ b/catch-error/README.md
@@ -23,13 +23,13 @@ Run `deno task test` or `deno task test:ci` to execute the unit tests via
 ```ts
 import { catchError } from "@observable/catch-error";
 import { throwError } from "@observable/throw-error";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 
 const controller = new AbortController();
 pipe(
   throwError(new Error("error")),
-  catchError(() => forOf(["fallback"])),
+  catchError(() => of("fallback")),
 ).subscribe({
   signal: controller.signal,
   next: (value) => console.log("next", value),
@@ -61,14 +61,14 @@ USAGE PATTERN:
 ```ts
 import { catchError } from "@observable/catch-error";
 import { throwError } from "@observable/throw-error";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 
 const controller = new AbortController();
 
 pipe(
   throwError(new Error("something went wrong")),
-  catchError((error) => forOf(["fallback value"]))
+  catchError((error) => of("fallback value"))
 ).subscribe({
   signal: controller.signal,
   next: (value) => console.log(value),  // "fallback value"
@@ -84,7 +84,7 @@ pipe(
   catchError((error) => {
     console.error("Caught:", error);
     // Return a fallback Observable
-    return forOf(["default"]);
+    return of("default");
   })
 ).subscribe({ ... });
 ```
@@ -97,7 +97,7 @@ pipe(
   someObservable,
   catchError((error) => {
     if (error instanceof RecoverableError) {
-      return forOf(["recovered"]);
+      return of("recovered");
     }
     // Re-throw unrecoverable errors
     return throwError(error);

--- a/catch-error/deno.json
+++ b/catch-error/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/catch-error",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/catch-error/mod.test.ts
+++ b/catch-error/mod.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { Observer, Subject } from "@observable/core";
 import { pipe } from "@observable/pipe";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { materialize, type ObserverNotification } from "@observable/materialize";
 import { catchError } from "./mod.ts";
 import { throwError } from "@observable/throw-error";
@@ -14,7 +15,7 @@ Deno.test("catchError should catch errors and emit values from project", () => {
   const source = flat([forOf([1, 2]), throwError(error)]);
   const materialized = pipe(
     source,
-    catchError(() => forOf(["recovered"])),
+    catchError(() => of("recovered")),
     materialize(),
   );
 
@@ -42,7 +43,7 @@ Deno.test("catchError should pass error value to project", () => {
     source,
     catchError((err) => {
       receivedError = err;
-      return forOf(["handled"]);
+      return of("handled");
     }),
     materialize(),
   );
@@ -84,7 +85,7 @@ Deno.test("catchError should pass through values if no error occurs", () => {
   const source = forOf([1, 2, 3]);
   const materialized = pipe(
     source,
-    catchError(() => forOf([999])),
+    catchError(() => of(999)),
     materialize(),
   );
 
@@ -108,7 +109,7 @@ Deno.test("catchError should pass through return", () => {
   const source = forOf([] as number[]);
   const materialized = pipe(
     source,
-    catchError(() => forOf([999])),
+    catchError(() => of(999)),
     materialize(),
   );
 
@@ -128,7 +129,7 @@ Deno.test("catchError should honor unsubscribe", () => {
   const source = forOf([1, 2, 3, 4, 5]);
   const materialized = pipe(
     source,
-    catchError(() => forOf([999])),
+    catchError(() => of(999)),
     materialize(),
   );
 
@@ -154,7 +155,7 @@ Deno.test("catchError should honor unsubscribe during error handling", () => {
   const controller = new AbortController();
   const error = new Error("test");
   const notifications: Array<ObserverNotification<number>> = [];
-  const source = flat([forOf([1]), throwError(error)]);
+  const source = flat([of(1), throwError(error)]);
   const recoverySource = forOf([10, 20, 30]);
   const materialized = pipe(
     source,
@@ -200,7 +201,7 @@ Deno.test("catchError should throw when project is not a function", () => {
 
 Deno.test("catchError should throw when called without source", () => {
   // Arrange
-  const operator = catchError(() => forOf([1]));
+  const operator = catchError(() => of(1));
 
   // Act / Assert
   assertThrows(
@@ -212,7 +213,7 @@ Deno.test("catchError should throw when called without source", () => {
 
 Deno.test("catchError should throw when source is not an Observable", () => {
   // Arrange
-  const operator = catchError(() => forOf([1]));
+  const operator = catchError(() => of(1));
 
   // Act / Assert
   assertThrows(
@@ -230,7 +231,7 @@ Deno.test("catchError should work with Subject", () => {
   const source = new Subject<number>();
   const materialized = pipe(
     source,
-    catchError(() => forOf(["caught"])),
+    catchError(() => of("caught")),
     materialize(),
   );
 

--- a/catch-error/mod.ts
+++ b/catch-error/mod.ts
@@ -11,13 +11,13 @@ import { from } from "@observable/from";
  * ```ts
  * import { catchError } from "@observable/catch-error";
  * import { throwError } from "@observable/throw-error";
- * import { forOf } from "@observable/for-of";
+ * import { of } from "@observable/of";
  * import { pipe } from "@observable/pipe";
  *
  * const controller = new AbortController();
  * pipe(
  *   throwError(new Error("error")),
- *   catchError(() => forOf(["fallback"])),
+ *   catchError(() => of("fallback")),
  * ).subscribe({
  *   signal: controller.signal,
  *   next: (value) => console.log("next", value),

--- a/debounce/mod.ts
+++ b/debounce/mod.ts
@@ -7,7 +7,7 @@ import { timeout } from "@observable/timeout";
 import { drop } from "@observable/drop";
 import { from } from "@observable/from";
 import { flat } from "@observable/flat";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 
 /**
  * Debounces the [`next`](https://jsr.io/@observable/core/doc/~/Observer.next)ed values from the
@@ -50,9 +50,7 @@ export function debounce<Value>(
     if (milliseconds === 0) return from(source);
     return pipe(
       source,
-      switchMap((value) =>
-        flat([pipe(timeout(milliseconds), drop<never>(Infinity)), forOf([value])])
-      ),
+      switchMap((value) => flat([pipe(timeout(milliseconds), drop<never>(Infinity)), of(value)])),
     );
   };
 }

--- a/defer/README.md
+++ b/defer/README.md
@@ -100,9 +100,12 @@ deferred.subscribe({
 LAZY EVALUATION:
 The factory is called at subscription time, not creation time:
 ```ts
+import { defer } from "@observable/defer";
+import { of } from "@observable/of";
+
 const deferred = defer(() => {
   console.log("Factory called!");  // Only when subscribed
-  return forOf([Date.now()]);
+  return of(Date.now());
 });
 // Factory not called yet...
 deferred.subscribe({ ... });  // "Factory called!"

--- a/defer/deno.json
+++ b/defer/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/defer",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/deno.json
+++ b/deno.json
@@ -32,6 +32,7 @@
     "merge",
     "merge-map",
     "never",
+    "of",
     "of-promise",
     "pairwise",
     "pipe",

--- a/distinct-until-changed/deno.json
+++ b/distinct-until-changed/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/distinct-until-changed",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/distinct-until-changed/mod.ts
+++ b/distinct-until-changed/mod.ts
@@ -6,7 +6,7 @@ import { map } from "@observable/map";
 import { filter } from "@observable/filter";
 import { pairwise } from "@observable/pairwise";
 import { flat } from "@observable/flat";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 
 /**
  * Flag indicating that no value has been emitted yet.
@@ -52,7 +52,7 @@ export function distinctUntilChanged<Value>(
     if (!isObservable(source)) throw new ParameterTypeError(0, "Observable");
     source = from(source);
     return pipe(
-      flat([forOf([noValue]), source]),
+      flat([of(noValue), source]),
       pairwise(),
       filter(isDistinct),
       map(([_, current]) => current),

--- a/each-value-from/deno.json
+++ b/each-value-from/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/each-value-from",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/each-value-from/mod.test.ts
+++ b/each-value-from/mod.test.ts
@@ -3,6 +3,7 @@ import { Observable, type Observer, Subject } from "@observable/core";
 import { pipe } from "@observable/pipe";
 import { eachValueFrom } from "./mod.ts";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { throwError } from "@observable/throw-error";
 import { empty } from "@observable/empty";
 import { flat } from "@observable/flat";
@@ -189,7 +190,7 @@ Deno.test("eachValueFrom throw method should abort subscription and reject", asy
   let subscriptionAborted = false;
   const error = new Error("iterator throw");
   const source = pipe(
-    flat([forOf([1]), never]),
+    flat([of(1), never]),
     finalize(() => subscriptionAborted = true),
   );
   const generator = eachValueFrom(source);
@@ -301,7 +302,7 @@ Deno.test("eachValueFrom should only start subscription on first next call", asy
   let subscribed = false;
   const source = defer(() => {
     subscribed = true;
-    return forOf([1]);
+    return of(1);
   });
   const generator = eachValueFrom(source);
 

--- a/expand/README.md
+++ b/expand/README.md
@@ -21,7 +21,7 @@ Run `deno task test` or `deno task test:ci` to execute the unit tests via
 
 ```ts
 import { expand } from "@observable/expand";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 import { empty } from "@observable/empty";
 
@@ -29,8 +29,8 @@ const controller = new AbortController();
 
 // Recursively double values until >= 16
 pipe(
-  forOf([2]),
-  expand((value) => value < 16 ? forOf([value * 2]) : empty),
+  of(2),
+  expand((value) => value < 16 ? of(value * 2) : empty),
 ).subscribe({
   signal: controller.signal,
   next: (value) => console.log("next", value),
@@ -48,6 +48,7 @@ pipe(
 
 ```ts
 import { expand } from "@observable/expand";
+import { of } from "@observable/of";
 import { forOf } from "@observable/for-of";
 import { pipe } from "@observable/pipe";
 import { empty } from "@observable/empty";
@@ -68,7 +69,7 @@ const tree: Node = {
 const controller = new AbortController();
 
 pipe(
-  forOf([tree]),
+  of(tree),
   expand((node) => node.children.length ? forOf(node.children) : empty),
 ).subscribe({
   signal: controller.signal,
@@ -108,7 +109,7 @@ CRITICAL: This library is NOT RxJS. Key differences:
 USAGE PATTERN:
 ```ts
 import { expand } from "@observable/expand";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 import { empty } from "@observable/empty";
 
@@ -116,8 +117,8 @@ const controller = new AbortController();
 
 // Recursively double until >= 16
 pipe(
-  forOf([2]),
-  expand((value) => value < 16 ? forOf([value * 2]) : empty)
+  of(2),
+  expand((value) => value < 16 ? of(value * 2) : empty)
 ).subscribe({
   signal: controller.signal,
   next: (value) => console.log(value),  // 2, 4, 8, 16

--- a/expand/deno.json
+++ b/expand/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/expand",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/expand/mod.test.ts
+++ b/expand/mod.test.ts
@@ -4,6 +4,7 @@ import { MinimumArgumentsRequiredError, noop, ParameterTypeError } from "@observ
 import { pipe } from "@observable/pipe";
 import { materialize, type ObserverNotification } from "@observable/materialize";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { empty } from "@observable/empty";
 import { expand } from "./mod.ts";
 
@@ -44,10 +45,10 @@ Deno.test("expand operator function should throw if source is not an Observable"
 Deno.test("expand should emit source values and recursively expand", () => {
   // Arrange
   const notifications: Array<ObserverNotification<number>> = [];
-  const source = forOf([2] as number[]);
+  const source = of(2);
   const observable = pipe(
     source,
-    expand((value) => value < 16 ? forOf([value * 2]) : empty),
+    expand((value) => value < 16 ? of(value * 2) : empty),
     materialize(),
   );
 
@@ -72,7 +73,7 @@ Deno.test("expand should handle multiple source values", () => {
   const source = forOf([1, 10] as number[]);
   const observable = pipe(
     source,
-    expand((value) => value < 4 || (value >= 10 && value < 40) ? forOf([value * 2]) : empty),
+    expand((value) => value < 4 || (value >= 10 && value < 40) ? of(value * 2) : empty),
     materialize(),
   );
 
@@ -97,12 +98,12 @@ Deno.test("expand should pass index to project function", () => {
   // Arrange
   const notifications: Array<ObserverNotification<number>> = [];
   const indices: number[] = [];
-  const source = forOf([1] as number[]);
+  const source = of(1);
   const observable = pipe(
     source,
     expand((value, index) => {
       indices.push(index);
-      return value < 4 ? forOf([value + 1]) : empty;
+      return value < 4 ? of(value + 1) : empty;
     }),
     materialize(),
   );
@@ -347,7 +348,7 @@ Deno.test("expand should return immediately when source is empty", () => {
   const notifications: Array<ObserverNotification<number>> = [];
   const observable = pipe(
     empty as Observable<number>,
-    expand((value) => forOf([value * 2])),
+    expand((value) => of(value * 2)),
     materialize(),
   );
 
@@ -431,10 +432,10 @@ Deno.test("expand should not return until all inner subscriptions return", () =>
 Deno.test("expand should handle deeply nested expansion", () => {
   // Arrange
   const notifications: Array<ObserverNotification<number>> = [];
-  const source = forOf([1] as number[]);
+  const source = of(1);
   const observable = pipe(
     source,
-    expand((value) => (value < 5 ? forOf([value + 1]) : empty)),
+    expand((value) => (value < 5 ? of(value + 1) : empty)),
     materialize(),
   );
 
@@ -457,7 +458,7 @@ Deno.test("expand should handle deeply nested expansion", () => {
 Deno.test("expand should handle branching expansion (multiple values from inner)", () => {
   // Arrange
   const notifications: Array<ObserverNotification<number>> = [];
-  const source = forOf([1] as number[]);
+  const source = of(1);
   const observable = pipe(
     source,
     expand((value) => value < 3 ? forOf([value * 2, value * 3]) : empty),
@@ -484,7 +485,7 @@ Deno.test("expand should have unique index counter per subscription", () => {
   // Arrange
   const indices1: number[] = [];
   const indices2: number[] = [];
-  const source = forOf([1] as number[]);
+  const source = of(1);
   const observable = pipe(
     source,
     expand((value, index) => {
@@ -493,7 +494,7 @@ Deno.test("expand should have unique index counter per subscription", () => {
       } else {
         indices2.push(index);
       }
-      return value < 4 ? forOf([value + 1]) : empty;
+      return value < 4 ? of(value + 1) : empty;
     }),
   );
 
@@ -510,19 +511,19 @@ Deno.test("expand should reset index for each new subscription", () => {
   // Arrange
   const allIndices1: number[] = [];
   const allIndices2: number[] = [];
-  const source = forOf([1] as number[]);
+  const source = of(1);
   const observable = pipe(
     source,
     expand((value, index) => {
       allIndices1.push(index);
-      return value < 3 ? forOf([value + 1]) : empty;
+      return value < 3 ? of(value + 1) : empty;
     }),
   );
   const observable2 = pipe(
     source,
     expand((value, index) => {
       allIndices2.push(index);
-      return value < 3 ? forOf([value + 1]) : empty;
+      return value < 3 ? of(value + 1) : empty;
     }),
   );
 
@@ -539,19 +540,19 @@ Deno.test("expand should have independent index counters for separate subscripti
   // Arrange
   const subscription1Indices: number[] = [];
   const subscription2Indices: number[] = [];
-  const source = forOf([1] as number[]);
+  const source = of(1);
   const wrapperObservable1 = pipe(
     source,
     expand((value, index) => {
       subscription1Indices.push(index);
-      return value < 3 ? forOf([value + 1]) : empty;
+      return value < 3 ? of(value + 1) : empty;
     }),
   );
   const wrapperObservable2 = pipe(
     source,
     expand((value, index) => {
       subscription2Indices.push(index);
-      return value < 3 ? forOf([value + 1]) : empty;
+      return value < 3 ? of(value + 1) : empty;
     }),
   );
 
@@ -572,8 +573,8 @@ Deno.test("expand should share index counter across all recursion levels within 
     source,
     expand((value, index) => {
       indicesWithValues.push([value, index]);
-      if (value === 1) return forOf([2]);
-      if (value === 10) return forOf([20]);
+      if (value === 1) return of(2);
+      if (value === 10) return of(20);
       return empty;
     }),
   );

--- a/expand/mod.ts
+++ b/expand/mod.ts
@@ -5,6 +5,7 @@ import { MinimumArgumentsRequiredError, ParameterTypeError } from "@observable/i
 import { mergeMap } from "@observable/merge-map";
 import { merge } from "@observable/merge";
 import { defer } from "@observable/defer";
+import { of } from "@observable/of";
 import { forOf } from "@observable/for-of";
 
 /**
@@ -14,7 +15,7 @@ import { forOf } from "@observable/for-of";
  * @example
  * ```ts
  * import { expand } from "@observable/expand";
- * import { forOf } from "@observable/for-of";
+ * import { of } from "@observable/of";
  * import { pipe } from "@observable/pipe";
  * import { empty } from "@observable/empty";
  *
@@ -22,8 +23,8 @@ import { forOf } from "@observable/for-of";
  *
  * // Recursively double values until >= 16
  * pipe(
- *   forOf([2]),
- *   expand((value) => value < 16 ? forOf([value * 2]) : empty),
+ *   of(2),
+ *   expand((value) => value < 16 ? of(value * 2) : empty),
  * ).subscribe({
  *   signal: controller.signal,
  *   next: (value) => console.log("next", value),
@@ -41,6 +42,7 @@ import { forOf } from "@observable/for-of";
  * @example
  * ```ts
  * import { expand } from "@observable/expand";
+ * import { of } from "@observable/of";
  * import { forOf } from "@observable/for-of";
  * import { pipe } from "@observable/pipe";
  * import { empty } from "@observable/empty";
@@ -63,7 +65,7 @@ import { forOf } from "@observable/for-of";
  *
  * pipe(
  *   [tree],
- *   forOf([root]),
+ *   of(root),
  *   expand((node) =>
  *     node.children.length ? forOf(node.children) : empty
  *   ),
@@ -99,7 +101,7 @@ export function expand<Value>(
         source,
         mergeMap((value) =>
           merge([
-            forOf([value]),
+            of(value),
             pipe(defer(() => project(value, index++)), expand((value) => project(value, index++))),
           ])
         ),

--- a/expand/mod.ts
+++ b/expand/mod.ts
@@ -6,7 +6,6 @@ import { mergeMap } from "@observable/merge-map";
 import { merge } from "@observable/merge";
 import { defer } from "@observable/defer";
 import { of } from "@observable/of";
-import { forOf } from "@observable/for-of";
 
 /**
  * Recursively {@linkcode project|projects} each [source](https://jsr.io/@observable/core#source) value

--- a/expand/mod.ts
+++ b/expand/mod.ts
@@ -64,8 +64,7 @@ import { forOf } from "@observable/for-of";
  * const controller = new AbortController();
  *
  * pipe(
- *   [tree],
- *   of(root),
+ *   of(tree),
  *   expand((node) =>
  *     node.children.length ? forOf(node.children) : empty
  *   ),

--- a/map/deno.json
+++ b/map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/map",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/map/mod.test.ts
+++ b/map/mod.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { Observable, Observer } from "@observable/core";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 import { throwError } from "@observable/throw-error";
 import { map } from "./mod.ts";
@@ -99,7 +100,7 @@ Deno.test("map should throw if the project function throws", () => {
   const error = new Error("test");
   const notifications: Array<ObserverNotification<number>> = [];
   const observable = pipe(
-    forOf([1]),
+    of(1),
     map(() => {
       throw error;
     }),

--- a/of/README.md
+++ b/of/README.md
@@ -1,0 +1,81 @@
+# [@observable/of](https://jsr.io/@observable/of)
+
+[`Next`](https://jsr.io/@observable/core/doc/~/Observer.next)s a provided value on
+[`subscribe`](https://jsr.io/@observable/core/doc/~/Observable.subscribe) and then
+[`return`](https://jsr.io/@observable/core/doc/~/Observer.return)s.
+
+## Build
+
+Automated by [JSR](https://jsr.io/)
+
+## Publishing
+
+Automated by `.github\workflows\publish.yml`.
+
+## Running unit tests
+
+Run `deno task test` or `deno task test:ci` to execute the unit tests via
+[Deno](https://deno.land/).
+
+## Examples
+
+```ts
+import { of } from "@observable/of";
+
+const activeSubscriptionController = new AbortController();
+
+of(1).subscribe({
+  signal: activeSubscriptionController.signal,
+  next: (value) => console.log("next", value),
+  return: () => console.log("return"),
+  throw: (value) => console.error("throw", value),
+});
+
+// Console output:
+// "next" 1
+// "return"
+```
+
+# AI Prompt
+
+Use the following prompt with AI assistants to help them understand this library:
+
+````
+You are helping me with code that uses @observable/of from the @observable library ecosystem.
+
+WHAT IT DOES:
+`of(value)` creates an Observable that emits a single value, then calls `return()`.
+
+CRITICAL DIFFERENCES FROM RxJS:
+- Takes a SINGLE value argument — NOT variadic arguments; use @observable/for-of for iterables
+- Observer uses `return`/`throw` — NOT `complete`/`error`
+- Unsubscription via `AbortController.abort()` — NOT `subscription.unsubscribe()`
+
+CORRECT USAGE:
+```ts
+import { of } from "@observable/of";
+
+const controller = new AbortController();
+
+// ✓ CORRECT: Pass a single value
+of(1).subscribe({
+  signal: controller.signal,
+  next: (value) => console.log(value),  // 1
+  return: () => console.log("done"),
+  throw: (error) => console.error(error),
+});
+```
+
+WRONG USAGE:
+```ts
+// ✗ WRONG: Variadic arguments don't work like RxJS
+of(1, 2, 3)  // This does NOT work!
+
+// ✗ For multiple values, use @observable/for-of with an iterable
+of([1, 2, 3])  // Emits the array as one value, not 1, 2, 3
+```
+````
+
+# Glossary And Semantics
+
+[@observable/core](https://jsr.io/@observable/core#glossary-and-semantics)

--- a/of/deno.json
+++ b/of/deno.json
@@ -1,6 +1,6 @@
 {
-  "name": "@observable/debounce",
-  "version": "0.12.0",
+  "name": "@observable/of",
+  "version": "0.7.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/of/mod.test.ts
+++ b/of/mod.test.ts
@@ -1,0 +1,29 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { of } from "./mod.ts";
+import { Observer } from "@observable/core";
+import { pipe } from "@observable/pipe";
+import { materialize, type ObserverNotification } from "@observable/materialize";
+
+Deno.test("of should next the provided value and then return", () => {
+  // Arrange
+  const value = Math.random();
+  const observable = of(value);
+  const notifications: Array<ObserverNotification<number>> = [];
+
+  // Act
+  pipe(observable, materialize()).subscribe(
+    new Observer((notification) => notifications.push(notification)),
+  );
+
+  // Assert
+  assertEquals(notifications, [["next", value], ["return"]]);
+});
+
+Deno.test("of should throw when called with no arguments", () => {
+  // Arrange / Act / Assert
+  assertThrows(
+    () => of(...([] as unknown as Parameters<typeof of>)),
+    TypeError,
+    "1 argument required but 0 present",
+  );
+});

--- a/of/mod.ts
+++ b/of/mod.ts
@@ -1,0 +1,30 @@
+import type { Observable } from "@observable/core";
+import { MinimumArgumentsRequiredError } from "@observable/internal";
+import { forOf } from "@observable/for-of";
+
+/**
+ * [`Next`](https://jsr.io/@observable/core/doc/~/Observer.next)s a provided {@linkcode value}
+ * on [`subscribe`](https://jsr.io/@observable/core/doc/~/Observable.subscribe) and then
+ * [`return`](https://jsr.io/@observable/core/doc/~/Observer.return)s.
+ * @example
+ * ```ts
+ * import { of } from "@observable/of";
+ *
+ * const activeSubscriptionController = new AbortController();
+ *
+ * of(1).subscribe({
+ *   signal: activeSubscriptionController.signal,
+ *   next: (value) => console.log("next", value),
+ *   return: () => console.log("return"),
+ *   throw: (value) => console.error("throw", value),
+ * });
+ *
+ * // Console output:
+ * // "next" 1
+ * // "return"
+ * ```
+ */
+export function of<const Value>(value: Value): Observable<Value> {
+  if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
+  return forOf([value]);
+}

--- a/pairwise/deno.json
+++ b/pairwise/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/pairwise",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/pairwise/mod.test.ts
+++ b/pairwise/mod.test.ts
@@ -4,6 +4,7 @@ import { Observer, Subject } from "@observable/core";
 import { throwError } from "@observable/throw-error";
 import { pipe } from "@observable/pipe";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { materialize, type ObserverNotification } from "@observable/materialize";
 import { pairwise } from "./mod.ts";
 
@@ -31,7 +32,7 @@ Deno.test("pairwise should emit pairs of consecutive values", () => {
 Deno.test("pairwise should not emit if source emits only one value", () => {
   // Arrange
   const notifications: Array<ObserverNotification<readonly [number, number]>> = [];
-  const source = forOf([1]);
+  const source = of(1);
   const materialized = pipe(source, pairwise(), materialize());
 
   // Act

--- a/reduce/deno.json
+++ b/reduce/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/reduce",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/reduce/mod.test.ts
+++ b/reduce/mod.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { Observable, Observer } from "@observable/core";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 import { throwError } from "@observable/throw-error";
 import { reduce } from "./mod.ts";
@@ -128,7 +129,7 @@ Deno.test("reduce should throw if the accumulator function throws", () => {
   const error = new Error("test");
   const notifications: Array<ObserverNotification<number>> = [];
   const observable = pipe(
-    forOf([1]),
+    of(1),
     reduce(() => {
       throw error;
     }, 0),
@@ -169,7 +170,7 @@ Deno.test("reduce should emit single value for source with one item", () => {
   // Arrange
   const notifications: Array<ObserverNotification<number>> = [];
   const observable = pipe(
-    forOf([42]),
+    of(42),
     reduce((previous, current) => previous + current, 0),
     materialize(),
   );

--- a/repeat/README.md
+++ b/repeat/README.md
@@ -31,6 +31,7 @@ Run `deno task test` or `deno task test:ci` to execute the unit tests via
 ```ts
 import { repeat } from "@observable/repeat";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 import { empty } from "@observable/empty";
 import { defer } from "@observable/defer";
@@ -43,7 +44,7 @@ const repeated = defer(() => {
     source,
     repeat(defer(() => {
       console.log("notifier subscribed");
-      return ++count === 2 ? empty : forOf([undefined]);
+      return ++count === 2 ? empty : of(undefined);
     })),
   );
 });
@@ -87,6 +88,7 @@ USAGE PATTERN:
 ```ts
 import { repeat } from "@observable/repeat";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 import { defer } from "@observable/defer";
 import { empty } from "@observable/empty";
@@ -98,7 +100,7 @@ let count = 0;
 pipe(
   source,
   repeat(defer(() => {
-    return ++count < 3 ? forOf([undefined]) : empty;
+    return ++count < 3 ? of(undefined) : empty;
   }))
 ).subscribe({
   signal: controller.signal,

--- a/repeat/deno.json
+++ b/repeat/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/repeat",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/repeat/mod.test.ts
+++ b/repeat/mod.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { Observer, Subject } from "@observable/core";
 import { pipe } from "@observable/pipe";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { materialize, type ObserverNotification } from "@observable/materialize";
 import { repeat } from "./mod.ts";
 import { take } from "@observable/take";
@@ -15,7 +16,7 @@ Deno.test("repeat should repeat source when notifier emits", () => {
   const notifications: Array<ObserverNotification<number>> = [];
   const source = forOf([1, 2, 3]);
   let repeatCount = 0;
-  const notifier = defer(() => ++repeatCount >= 3 ? empty : forOf([undefined]));
+  const notifier = defer(() => ++repeatCount >= 3 ? empty : of(undefined));
   const materialized = pipe(source, repeat(notifier), materialize());
 
   // Act
@@ -63,8 +64,8 @@ Deno.test("repeat should propagate throws from source", () => {
   // Arrange
   const error = new Error("source error");
   const notifications: Array<ObserverNotification<number>> = [];
-  const source = flat([forOf([1]), throwError(error)]);
-  const notifier = forOf([undefined]);
+  const source = flat([of(1), throwError(error)]);
+  const notifier = of(undefined);
   const materialized = pipe(source, repeat(notifier), materialize());
 
   // Act
@@ -125,7 +126,7 @@ Deno.test("repeat should work with Subject as notifier", () => {
 Deno.test("repeat should repeat indefinitely with default notifier", () => {
   // Arrange
   const notifications: Array<ObserverNotification<number>> = [];
-  const source = forOf([1]);
+  const source = of(1);
   const materialized = pipe(source, repeat(), take(5), materialize());
 
   // Act
@@ -149,7 +150,7 @@ Deno.test("repeat should honor unsubscribe during source", () => {
   const controller = new AbortController();
   const notifications: Array<ObserverNotification<number>> = [];
   const source = forOf([1, 2, 3, 4, 5]);
-  const notifier = forOf([undefined]);
+  const notifier = of(undefined);
   const materialized = pipe(source, repeat(notifier), materialize());
 
   // Act
@@ -173,7 +174,7 @@ Deno.test("repeat should honor unsubscribe during notifier", () => {
   // Arrange
   const controller = new AbortController();
   const notifications: Array<ObserverNotification<number>> = [];
-  const source = forOf([1]);
+  const source = of(1);
   const notifier = new Subject<void>();
   const materialized = pipe(source, repeat(notifier), materialize());
 
@@ -206,7 +207,7 @@ Deno.test("repeat should throw when notifier is not an Observable", () => {
 
 Deno.test("repeat should throw when called with no source", () => {
   // Arrange
-  const operator = repeat(forOf([undefined]));
+  const operator = repeat(of(undefined));
 
   // Act / Assert
   assertThrows(
@@ -218,7 +219,7 @@ Deno.test("repeat should throw when called with no source", () => {
 
 Deno.test("repeat should throw when source is not an Observable", () => {
   // Arrange
-  const operator = repeat(forOf([undefined]));
+  const operator = repeat(of(undefined));
 
   // Act / Assert
   assertThrows(
@@ -233,7 +234,7 @@ Deno.test("repeat should only use first emission from notifier per repeat cycle"
   // Arrange
   let notifierEmissions = 0;
   const notifications: Array<ObserverNotification<number>> = [];
-  const source = forOf([1]);
+  const source = of(1);
   const notifier = defer(() => {
     notifierEmissions++;
     return forOf([undefined, undefined, undefined]);
@@ -269,7 +270,7 @@ Deno.test("repeat should work with defer notifier for controlled repetition", ()
       repeat(
         defer(() => {
           notifierSubscriptions.push(++count);
-          return count === 2 ? empty : forOf([undefined]);
+          return count === 2 ? empty : of(undefined);
         }),
       ),
     );
@@ -319,7 +320,7 @@ Deno.test("repeat should resubscribe to source on each repeat", () => {
     return forOf([subscriptionCount * 10 + 1, subscriptionCount * 10 + 2]);
   });
   let repeatCount = 0;
-  const notifier = defer(() => ++repeatCount >= 2 ? empty : forOf([undefined]));
+  const notifier = defer(() => ++repeatCount >= 2 ? empty : of(undefined));
   const materialized = pipe(source, repeat(notifier), materialize());
 
   // Act

--- a/repeat/mod.ts
+++ b/repeat/mod.ts
@@ -5,7 +5,7 @@ import { pipe } from "@observable/pipe";
 import { flat } from "@observable/flat";
 import { take } from "@observable/take";
 import { mergeMap } from "@observable/merge-map";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 
 /**
  * Re-[`subscribe`](https://jsr.io/@observable/core/doc/~/Observable.subscribe)s to the
@@ -18,7 +18,7 @@ import { forOf } from "@observable/for-of";
  * @example
  * ```ts
  * import { repeat } from "@observable/repeat";
- * import { forOf } from "@observable/for-of";
+ * import { of } from "@observable/of";
  * import { pipe } from "@observable/pipe";
  * import { empty } from "@observable/empty";
  * import { defer } from "@observable/defer";
@@ -31,7 +31,7 @@ import { forOf } from "@observable/for-of";
  *     source,
  *     repeat(defer(() => {
  *      console.log("notifier subscribed");
- *      return ++count === 2 ? empty : forOf([undefined]);
+ *      return ++count === 2 ? empty : of(undefined);
  *     })),
  *   );
  * });
@@ -56,7 +56,7 @@ import { forOf } from "@observable/for-of";
  * ```
  */
 export function repeat<Value>(
-  notifier: Observable = forOf([undefined]),
+  notifier: Observable = of(undefined),
 ): (source: Observable<Value>) => Observable<Value> {
   if (!isObservable(notifier)) throw new ParameterTypeError(0, "Observable");
   notifier = from(notifier);

--- a/scan/deno.json
+++ b/scan/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/scan",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/scan/mod.test.ts
+++ b/scan/mod.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { Observable, Observer } from "@observable/core";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 import { throwError } from "@observable/throw-error";
 import { scan } from "./mod.ts";
@@ -122,7 +123,7 @@ Deno.test("scan should throw if the accumulator function throws", () => {
   const error = new Error("test");
   const notifications: Array<ObserverNotification<number>> = [];
   const observable = pipe(
-    forOf([1]),
+    of(1),
     scan(() => {
       throw error;
     }, 0),

--- a/share/deno.json
+++ b/share/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/share",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/share/mod.test.ts
+++ b/share/mod.test.ts
@@ -3,6 +3,7 @@ import { Observer, Subject } from "@observable/core";
 import { pipe } from "@observable/pipe";
 import { share } from "./mod.ts";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { throwError } from "@observable/throw-error";
 import { materialize, type ObserverNotification } from "@observable/materialize";
 import { ReplaySubject } from "@observable/replay-subject";
@@ -119,7 +120,7 @@ Deno.test("share should not subscribe to source until first observer", () => {
   let subscribed = false;
   const source = defer(() => {
     subscribed = true;
-    return forOf([1]);
+    return of(1);
   });
   const shared = pipe(source, share());
   assertStrictEquals(subscribed, false);
@@ -325,7 +326,7 @@ Deno.test("share should create new source subscription after source returns", ()
   let sourceSubscribeCount = 0;
   const source = defer(() => {
     sourceSubscribeCount++;
-    return forOf([sourceSubscribeCount]);
+    return of(sourceSubscribeCount);
   });
   const shared = pipe(source, share());
   const notifications1: Array<ObserverNotification<number>> = [];

--- a/switch-map/deno.json
+++ b/switch-map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/switch-map",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/switch-map/mod.ts
+++ b/switch-map/mod.ts
@@ -18,7 +18,7 @@ import { mergeMap } from "@observable/merge-map";
  * ```ts
  * import { BehaviorSubject } from "@observable/behavior-subject";
  * import { switchMap } from "@observable/switch-map";
- * import { forOf } from "@observable/for-of";
+ * import { of } from "@observable/of";
  * import { pipe } from "@observable/pipe";
  *
  * const page = new BehaviorSubject(1);
@@ -31,7 +31,7 @@ import { mergeMap } from "@observable/merge-map";
  * });
  *
  * function fetchPage(page: number): Observable<string> {
- *   return forOf([`Page ${page}`]);
+ *   return of(`Page ${page}`);
  * }
  */
 export function switchMap<In, Out>(

--- a/tap/deno.json
+++ b/tap/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/tap",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/tap/mod.test.ts
+++ b/tap/mod.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { Observable, Observer } from "@observable/core";
 import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { pipe } from "@observable/pipe";
 import { throwError } from "@observable/throw-error";
 import { tap } from "./mod.ts";
@@ -183,7 +184,7 @@ Deno.test("tap callback error should be delivered as throw notification without 
   const error = new Error("callback error");
   const notifications: Array<ObserverNotification<number>> = [];
   const observable = pipe(
-    forOf([1]),
+    of(1),
     tap(() => {
       throw error;
     }),
@@ -227,7 +228,7 @@ Deno.test("tap should execute side-effect before downstream receives value", () 
   // Arrange
   const order: Array<string> = [];
   const observable = pipe(
-    forOf([1]),
+    of(1),
     tap(() => order.push("tap")),
     materialize(),
   );

--- a/throttle/deno.json
+++ b/throttle/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/throttle",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/throttle/mod.ts
+++ b/throttle/mod.ts
@@ -6,7 +6,7 @@ import { pipe } from "@observable/pipe";
 import { exhaustMap } from "@observable/exhaust-map";
 import { filter } from "@observable/filter";
 import { flat } from "@observable/flat";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { timeout } from "@observable/timeout";
 import { drop } from "@observable/drop";
 
@@ -56,9 +56,7 @@ export function throttle<Value>(
     if (milliseconds === 0) return from(source);
     return pipe(
       source,
-      exhaustMap((value) =>
-        flat([forOf([value]), pipe(timeout(milliseconds), drop<never>(Infinity))])
-      ),
+      exhaustMap((value) => flat([of(value), pipe(timeout(milliseconds), drop<never>(Infinity))])),
     );
   };
 }

--- a/throw-error/README.md
+++ b/throw-error/README.md
@@ -64,10 +64,10 @@ COMMON USE — Conditional errors:
 ```ts
 import { pipe } from "@observable/pipe";
 import { flatMap } from "@observable/flat-map";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 
 pipe(
-  forOf([userId]),
+  of(userId),
   flatMap((id) =>
     id ? fetchUser(id) : throwError(new Error("User ID required"))
   )

--- a/throw-error/deno.json
+++ b/throw-error/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/throw-error",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/timeout/deno.json
+++ b/timeout/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/timeout",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/timeout/mod.ts
+++ b/timeout/mod.ts
@@ -1,7 +1,7 @@
 import { MinimumArgumentsRequiredError, ParameterTypeError } from "@observable/internal";
 import { Observable } from "@observable/core";
 import { empty } from "@observable/empty";
-import { forOf } from "@observable/for-of";
+import { of } from "@observable/of";
 import { never } from "@observable/never";
 import { pipe } from "@observable/pipe";
 import { take } from "@observable/take";
@@ -76,7 +76,7 @@ export function timeout(milliseconds: number): Observable<void> {
   if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
   if (typeof milliseconds !== "number") throw new ParameterTypeError(0, "Number");
   if (milliseconds < 0 || Number.isNaN(milliseconds)) return empty;
-  if (milliseconds === 0) return forOf([undefined]);
+  if (milliseconds === 0) return of(undefined);
   if (milliseconds === Infinity) return never;
   return pipe(
     new Observable<void>((observer) => {


### PR DESCRIPTION
- Incremented version for `@observable/async-subject` to 0.10.0 and `@observable/catch-error` to 0.9.0.
- Introduced the `of` operator in various modules, replacing instances of `forOf` to enhance clarity and consistency in value emissions.
- Updated `deno.json` to include the new `of` operator.
- Refactored tests and documentation to reflect the usage of the `of` operator, ensuring all examples align with the updated operator structure.
- Enhanced README files across multiple modules to demonstrate the correct usage of the `of` operator, improving overall documentation quality.