### PR TITLE
Update version to 0.9.0 and enhance tests for Observable and Observer

### DIFF
--- a/all/deno.json
+++ b/all/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/all",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/async-subject/deno.json
+++ b/async-subject/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/async-subject",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/await-of/deno.json
+++ b/await-of/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/await-of",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/behavior-subject/deno.json
+++ b/behavior-subject/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/behavior-subject",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/broadcast-subject/deno.json
+++ b/broadcast-subject/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/broadcast-subject",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/catch-error/deno.json
+++ b/catch-error/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/catch-error",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/core/README.md
+++ b/core/README.md
@@ -87,10 +87,18 @@ This can be a wide variety of things, from a
 to a simple iteration over an
 [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).
 
+### Subscriber
+
+The [consumer](#consumer) that initiated the [subscription](#subscription).
+
 ### Subscription
 
 A contract where a [consumer](#consumer) is [observing](#observation) values pushed by a
-[producer](#producer).
+[producer](#producer). The subscription, is an ongoing process that amounts to the function of the
+[`Observable`](https://jsr.io/@observable/core/doc/~/Observable) from the [consumer](#consumer)'s
+perspective starting the moment of
+[`subscribe`](https://jsr.io/@observable/core/doc/~/Observable.subscribe) and ending the moment of
+[unsubscribe](https://jsr.io/@observable/core/doc/~/Observer.signal).
 
 ## Major Actions
 

--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/core/observable.test.ts
+++ b/core/observable.test.ts
@@ -24,6 +24,17 @@ Deno.test("Observable.prototype should be frozen", () => {
 });
 
 Deno.test(
+  "Observable should not freeze Object.prototype",
+  () => {
+    // Arrange / Act
+    new Observable(noop);
+
+    // Assert
+    assertStrictEquals(Object.isFrozen(Object.prototype), false);
+  },
+);
+
+Deno.test(
   "Observable.constructor should throw when creating with no arguments",
   () => {
     // Arrange / Act / Assert

--- a/core/observable.ts
+++ b/core/observable.ts
@@ -31,9 +31,7 @@ export const Observable: ObservableConstructor = class<Value> {
 
   constructor(subscribe: (observer: Observer<Value>) => void) {
     if (arguments.length === 0) throw new MinimumArgumentsRequiredError();
-    if (typeof subscribe !== "function") {
-      throw new ParameterTypeError(0, "Function");
-    }
+    if (typeof subscribe !== "function") throw new ParameterTypeError(0, "Function");
     Object.freeze(this);
     this.#subscribe = subscribe;
   }

--- a/core/observer.test.ts
+++ b/core/observer.test.ts
@@ -50,6 +50,17 @@ Deno.test("Observer.prototype should be frozen", () => {
   assertStrictEquals(Object.isFrozen(Observer.prototype), true);
 });
 
+Deno.test(
+  "Observer should not freeze Object.prototype",
+  () => {
+    // Arrange / Act
+    new Observer();
+
+    // Assert
+    assertStrictEquals(Object.isFrozen(Object.prototype), false);
+  },
+);
+
 Deno.test("Observer.constructor should create with no arguments", () => {
   // Arrange / Act / Assert
   new Observer();

--- a/core/subject.test.ts
+++ b/core/subject.test.ts
@@ -24,6 +24,17 @@ Deno.test("Subject.prototype should be frozen", () => {
 });
 
 Deno.test(
+  "Subject should not freeze Object.prototype",
+  () => {
+    // Arrange / Act
+    new Subject();
+
+    // Assert
+    assertStrictEquals(Object.isFrozen(Object.prototype), false);
+  },
+);
+
+Deno.test(
   "Subject.constructor should throw when creating with arguments",
   () => {
     // Arrange / Act / Assert

--- a/debounce/deno.json
+++ b/debounce/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/debounce",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/defer/deno.json
+++ b/defer/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/defer",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/distinct-until-changed/deno.json
+++ b/distinct-until-changed/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/distinct-until-changed",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/distinct/deno.json
+++ b/distinct/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/distinct",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/drop/deno.json
+++ b/drop/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/drop",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/each-value-from/deno.json
+++ b/each-value-from/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/each-value-from",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/empty/deno.json
+++ b/empty/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/empty",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/exhaust-map/deno.json
+++ b/exhaust-map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/exhaust-map",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/expand/deno.json
+++ b/expand/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/expand",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/fetch/deno.json
+++ b/fetch/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/fetch",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/filter/deno.json
+++ b/filter/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/filter",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/finalize/deno.json
+++ b/finalize/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/finalize",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/flat-map/deno.json
+++ b/flat-map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/flat-map",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/flat/deno.json
+++ b/flat/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/flat",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/for-await-of/deno.json
+++ b/for-await-of/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/for-await-of",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/for-of/deno.json
+++ b/for-of/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/for-of",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/interval/deno.json
+++ b/interval/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/interval",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/keep-alive/deno.json
+++ b/keep-alive/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/keep-alive",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/last-value-from/deno.json
+++ b/last-value-from/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/last-value-from",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/map/deno.json
+++ b/map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/map",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/materialize/deno.json
+++ b/materialize/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/materialize",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/merge-map/deno.json
+++ b/merge-map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/merge-map",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/merge/deno.json
+++ b/merge/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/merge",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/never/deno.json
+++ b/never/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/never",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/of/deno.json
+++ b/of/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/of",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/pairwise/deno.json
+++ b/pairwise/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/pairwise",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/race/deno.json
+++ b/race/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/race",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/reduce/deno.json
+++ b/reduce/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/reduce",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/repeat/deno.json
+++ b/repeat/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/repeat",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/replay-subject/deno.json
+++ b/replay-subject/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/replay-subject",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/rxjs-interop/deno.json
+++ b/rxjs-interop/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/rxjs-interop",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] },

--- a/scan/deno.json
+++ b/scan/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/scan",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/share/deno.json
+++ b/share/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/share",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/switch-map/deno.json
+++ b/switch-map/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/switch-map",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/take-until/deno.json
+++ b/take-until/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/take-until",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/take/deno.json
+++ b/take/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/take",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/tap/deno.json
+++ b/tap/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/tap",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/throttle/deno.json
+++ b/throttle/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/throttle",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/throw-error/deno.json
+++ b/throw-error/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/throw-error",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/timeout/deno.json
+++ b/timeout/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/timeout",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }


### PR DESCRIPTION
- Incremented version in `deno.json` to 0.9.0.
- Added tests to verify that `Observable` and `Observer` do not freeze `Object.prototype`.
- Simplified parameter type validation in the `Observable` constructor for improved clarity.