### PR TITLE
feat: use consistent iterable var naming conventions instead of the g…

### DIFF
--- a/all/deno.json
+++ b/all/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/all",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/all/mod.test.ts
+++ b/all/mod.test.ts
@@ -135,14 +135,14 @@ Deno.test("all should return empty when given an empty set", () => {
 Deno.test("all should be empty when given an empty iterable", () => {
   // Arrange
   const notifications: Array<ObserverNotification<ReadonlyArray<unknown>>> = [];
-  const iterable: Iterable<Observable<unknown>> = {
+  const observables: Iterable<Observable> = {
     [Symbol.iterator]: () => ({
       next: () => ({ done: true, value: undefined }),
       return: () => ({ done: true, value: undefined }),
       throw: () => ({ done: true, value: undefined }),
     }),
   };
-  const observable = all(iterable);
+  const observable = all(observables);
 
   // Act
   pipe(observable, materialize()).subscribe(

--- a/all/mod.ts
+++ b/all/mod.ts
@@ -139,23 +139,23 @@ export function all<Value>(
   observables: Iterable<Observable<Value>>,
 ): Observable<ReadonlyArray<Value>>;
 export function all<Value>(
-  iterable: Iterable<Observable<Value>>,
+  observables: Iterable<Observable<Value>>,
 ): Observable<ReadonlyArray<Value>> {
   if (!arguments.length) throw new TypeError("1 argument required but 0 present");
-  if (!isIterable(iterable)) throw new TypeError("Parameter 1 is not of type 'Iterable'");
+  if (!isIterable(observables)) throw new TypeError("Parameter 1 is not of type 'Iterable'");
 
-  if (Array.isArray(iterable) && !iterable.length) return empty;
-  if (iterable instanceof Set && !iterable.size) return empty;
+  if (Array.isArray(observables) && !observables.length) return empty;
+  if (observables instanceof Set && !observables.size) return empty;
 
   // We could compose a few different operators to achieve the same result, but this is
   // a more direct implementation that is easier to understand and reason about.
   return new Observable((observer) => {
     /**
-     * The bounded {@linkcode iterable} which has a known `size` for subsequent logic.
+     * The bounded {@linkcode observables} which has a known `size` for subsequent logic.
      */
-    const observables = bound(iterable);
+    const boundObservables = bound(observables);
 
-    if (!observables.size) return observer.return();
+    if (!boundObservables.size) return observer.return();
 
     /**
      * Tracking the number of first values that have been received.
@@ -164,7 +164,7 @@ export function all<Value>(
     /**
      * Tracking the number of active inner subscriptions.
      */
-    let activeInnerSubscriptions = observables.size;
+    let activeInnerSubscriptions = boundObservables.size;
 
     /**
      * Tracking a known list of {@linkcode buffer|buffered} values, so we don't have to clone them while nexting to prevent reentrant behaviors.
@@ -180,7 +180,7 @@ export function all<Value>(
      */
     let index = 0;
 
-    for (const observable of observables) {
+    for (const observable of boundObservables) {
       /**
        * Tracking if the {@linkcode observable} has pushed its first value.
        */
@@ -202,7 +202,7 @@ export function all<Value>(
             snapshot = undefined;
           }
 
-          if (receivedFirstValueCount === observables.size) {
+          if (receivedFirstValueCount === boundObservables.size) {
             observer.next(snapshot ??= Object.freeze(buffer.slice()));
           }
         },

--- a/for-of/deno.json
+++ b/for-of/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@observable/for-of",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "exports": "./mod.ts",
   "publish": { "exclude": ["*.test.ts"] }

--- a/for-of/mod.ts
+++ b/for-of/mod.ts
@@ -68,13 +68,13 @@ export function forOf<const Values extends ReadonlyArray<unknown>>(
  * // "return"
  * ```
  */
-export function forOf<Value>(iterable: Iterable<Value>): Observable<Value>;
-export function forOf<Value>(iterable: Iterable<Value>): Observable<Value> {
+export function forOf<Value>(values: Iterable<Value>): Observable<Value>;
+export function forOf<Value>(values: Iterable<Value>): Observable<Value> {
   if (!arguments.length) throw new TypeError("1 argument required but 0 present");
-  if (!isIterable(iterable)) throw new TypeError("Parameter 1 is not of type 'Iterable'");
-  if (Array.isArray(iterable) && !iterable.length) return empty;
+  if (!isIterable(values)) throw new TypeError("Parameter 1 is not of type 'Iterable'");
+  if (Array.isArray(values) && !values.length) return empty;
   return new Observable((observer) => {
-    for (const value of iterable) {
+    for (const value of values) {
       observer.next(value);
       if (observer.signal.aborted) return;
     }


### PR DESCRIPTION
…eneric 'iterables'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped `@observable/all` package to version 0.22.0
  * Bumped `for-of` package to version 0.10.0

* **Refactor**
  * Refined parameter naming conventions in `all` and `for-of` functions for improved consistency across the API

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexanderharding/observable/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->